### PR TITLE
Pin and make the project structure conform more to todomvc-nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
-{ pkgs ? import ./pkgs.nix }:
+args@{ pkgs ? import ./nix args, ... }:
 
 {
-  inherit (pkgs) arion;
-  tests = pkgs.callPackage ./tests {};
+  inherit (pkgs) arion tests;
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,13 @@
+/**
+ * This is the entry-point for all nix execution in this project.
+ */
+{ nixpkgsSrc ? ./nixpkgs.nix, ... }:
+import (import ./nixpkgs.nix) {
+  # Makes the config pure as well. See <nixpkgs>/top-level/impure.nix:
+  config = {
+  };
+  overlays = [
+    # all the packages are defined there:
+    (import ./overlay.nix)
+  ];
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,5 @@
+# to update: $ nix-prefetch-url --unpack url
+builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/be445a9074f139d63e704fa82610d25456562c3d.tar.gz";
+  sha256 = "15dc7gdspimavcwyw9nif4s59v79gk18rwsafylffs9m1ld2dxwa";
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,4 @@
+self: super: {
+  arion = super.callPackage ../arion.nix {};
+  tests = super.callPackage ../tests {};
+}

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,3 +1,0 @@
-import <nixpkgs> {
-  overlays = [ (self: super: { arion = super.callPackage ./arion.nix {}; }) ];
-}


### PR DESCRIPTION
This makes the Nix files work like [todomvc-nix](https://github.com/nix-community/todomvc-nix/) but a little simplified.
Also it pins nixpkgs because for development (tests), you need -unstable
instead of release-18.09 so that's automatic now.
