### PR TITLE
Use the word 'composition' where applicable.

### DIFF
--- a/src/arion
+++ b/src/arion
@@ -140,7 +140,7 @@ do_eval() {
   echo 1>&2 "Evaluating configuration..."
   # read-write-mode is required for import from derivation
   nix-instantiate \
-    "$nix_dir/eval-docker-compose.nix" \
+    "$nix_dir/eval-composition.nix" \
     --eval \
     --read-write-mode \
     --json \
@@ -155,7 +155,7 @@ do_eval() {
 do_build() {
   echo 1>&2 "Building configuration..."
   nix-build \
-    "$nix_dir/eval-docker-compose.nix" \
+    "$nix_dir/eval-composition.nix" \
     --out-link $docker_compose_yaml \
     --argstr uid "$UID" \
     --arg modules "$modules" \
@@ -190,7 +190,7 @@ To bring the top-level Nixpkgs attributes into scope
 
 EOF
     cat >"$REPL_TMP" <<EOF
-import $nix_dir/eval-docker-compose.nix {
+import $nix_dir/eval-composition.nix {
   uid = "$UID";
   modules = $modules;
   pkgs = $pkgs_argument;

--- a/src/nix/docker-compose-module.nix
+++ b/src/nix/docker-compose-module.nix
@@ -1,3 +1,14 @@
+/*
+
+   This is a composition-level module.
+
+   It defines the low-level options that are read by arion, like
+    - build.dockerComposeYaml
+
+   It declares options like
+    - docker-compose.services
+
+ */
 { pkgs, uid, lib, config, ... }:
 
 let

--- a/src/nix/eval-composition.nix
+++ b/src/nix/eval-composition.nix
@@ -11,7 +11,7 @@ let
 
   inherit (pkgs) lib;
 
-  composite = lib.evalModules {
+  composition = lib.evalModules {
     check = true;
     modules = builtinModules ++ modules;
   };
@@ -22,12 +22,12 @@ let
   ];
 
   argsModule = {
-    _file = ./eval-docker-compose.nix;
-    key = ./eval-docker-compose.nix;
+    _file = ./eval-composition.nix;
+    key = ./eval-composition.nix;
     config._module.args.pkgs = lib.mkIf (pkgs != null) (lib.mkForce pkgs);
     config._module.args.uid = uid;
   };
 
 in
-  # Typically you need composite.config.build.dockerComposeYaml
-  composite
+  # Typically you need composition.config.build.dockerComposeYaml
+  composition

--- a/src/nix/service-host-store.nix
+++ b/src/nix/service-host-store.nix
@@ -1,4 +1,9 @@
-# Bind-mounts the host store
+/*
+
+   This service-level bind mounts the host store into the container
+   when the service.useHostStore option is set to true.
+
+ */
 { lib, config, ... }:
 let
   inherit (lib) mkOption types mkIf;

--- a/src/nix/service.nix
+++ b/src/nix/service.nix
@@ -1,3 +1,9 @@
+/*
+
+   This service-level module defines the build.service option, using
+   the user-facing options service.image, service.volumes, etc.
+
+ */
 { pkgs, lib, config, ... }:
 
 let

--- a/tests/arion-test/default.nix
+++ b/tests/arion-test/default.nix
@@ -2,7 +2,7 @@
 
 let
   # To make some prebuilt derivations available in the vm
-  preEval = import ../../src/nix/eval-docker-compose.nix {
+  preEval = import ../../src/nix/eval-composition.nix {
     modules = [ ../../examples/minimal/arion-compose.nix ];
     inherit pkgs;
   };


### PR DESCRIPTION
Also adds some documentation to celebrate that we can now - with ease - verbally
distinguish between composition-level modules and service-level modules.

Closes #7 