### PR TITLE
Always ignore PATH docker-compose

### DIFF
--- a/src/arion
+++ b/src/arion
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PATH="$PATH:@path@"
+export PATH="@path@:$PATH"
 
 nix_dir="@nix_dir@"
 docker_compose_args=()


### PR DESCRIPTION
Arion used to prefer an external docker-compose, but that exposes
users to potential incompatibilities.

For example, the docker-compose on Ubuntu 18.04 (LTS) doesn't seem
to handle Dockerfiles in the Nix store properly.

Part of #3 