### PR TITLE
Replace /bin/sh, /usr/bin/env mounts by symlinks

### DIFF
--- a/arion.nix
+++ b/arion.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation {
       mkdir -p $out/bin $out/share/arion
       cp -a nix $out/share/arion/
       cp -a arion-image $out/share/arion/
+      tar -czf $out/share/arion/arion-image/tarball.tar.gz -C arion-image/tarball .
       substitute arion $out/bin/arion \
         --subst-var-by path ${lib.makeBinPath [jq coreutils docker_compose]} \
         --subst-var-by nix_dir $out/share/arion/nix \

--- a/src/arion-image/Dockerfile
+++ b/src/arion-image/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 COPY passwd /etc/passwd
+ADD tarball.tar.gz /

--- a/src/arion-image/tarball/bin/sh
+++ b/src/arion-image/tarball/bin/sh
@@ -1,0 +1,1 @@
+/run/system/bin/sh

--- a/src/arion-image/tarball/usr/bin/env
+++ b/src/arion-image/tarball/usr/bin/env
@@ -1,0 +1,1 @@
+/run/system/usr/bin/env

--- a/src/nix/service-host-store.nix
+++ b/src/nix/service-host-store.nix
@@ -4,7 +4,7 @@
    when the service.useHostStore option is set to true.
 
  */
-{ lib, config, ... }:
+{ lib, config, pkgs, ... }:
 let
   inherit (lib) mkOption types mkIf;
 in
@@ -21,8 +21,7 @@ in
     service.build.context = "${../arion-image}";
     service.volumes = [
       "/nix/store:/nix/store"
-      "/bin/sh:/bin/sh"
-      "/usr/bin/env:/usr/bin/env"
+      "${pkgs.buildEnv { name = "container-system-env"; paths = [ pkgs.bashInteractive pkgs.coreutils ]; }}:/run/system"
     ];
   };
 }

--- a/tests/arion-test/default.nix
+++ b/tests/arion-test/default.nix
@@ -18,11 +18,21 @@ in
     
     # no caches, because no internet
     nix.binaryCaches = lib.mkForce [];
+
+    # FIXME: Sandbox seems broken with current version of NixOS test
+    #        w/ writable store. Error:
+    #        machine# error: linking '/nix/store/7r8z2zvhwda85pgpdn5hzzz6hs1njklc-stdenv-linux.drv.chroot/nix/store/6v3y7s4q4wd16hsw393gjpxvcf9159bv-patch-shebangs.sh' to '/nix/store/6v3y7s4q4wd16hsw393gjpxvcf9159bv-patch-shebangs.sh': Operation not permitted
+    #
+    #        There should be no reason why arion can't run without
+    #        sandboxing, so please re-enable.
+    nix.useSandbox = false;
+
     virtualisation.writableStore = true;
     virtualisation.pathsInNixDB = [
       # Pre-build the image because we don't want to build the world
       # in the vm.
       preEval.config.build.dockerComposeYaml
+      pkgs.stdenv
     ];
   };
   testScript = ''


### PR DESCRIPTION
This makes the arion-base image compatible with hosts other than
NixOS.