### PR TITLE
feat: custom nix store

### DIFF
--- a/src/nix/docker-compose-module.nix
+++ b/src/nix/docker-compose-module.nix
@@ -9,7 +9,7 @@
     - docker-compose.services
 
  */
-{ pkgs, uid, lib, config, ... }:
+{ pkgs, uid, lib, config, customNixRootPath, ... }:
 
 let
   evalService = name: modules:
@@ -30,6 +30,7 @@ let
         key = ./docker-compose-module.nix;
         config._module.args.pkgs = lib.mkForce pkgs;
         config._module.args.uid = uid;
+        config._module.args.customNixRootPath = customNixRootPath;
       };
 
     in

--- a/src/nix/eval-composition.nix
+++ b/src/nix/eval-composition.nix
@@ -1,4 +1,4 @@
-{ modules ? [], uid ? 0, pkgs }:
+{ modules ? [], uid ? 0, pkgs, customNixRootPath ? "", }:
 
 let _pkgs = pkgs;
 in
@@ -26,6 +26,7 @@ let
     key = ./eval-composition.nix;
     config._module.args.pkgs = lib.mkIf (pkgs != null) (lib.mkForce pkgs);
     config._module.args.uid = uid;
+    config._module.args.customNixRootPath = customNixRootPath;
   };
 
 in

--- a/src/nix/service-host-store.nix
+++ b/src/nix/service-host-store.nix
@@ -4,7 +4,8 @@
    when the service.useHostStore option is set to true.
 
  */
-{ lib, config, pkgs, ... }:
+{ lib, config, pkgs, customNixRootPath, ... }:
+
 let
   inherit (lib) mkOption types mkIf;
 in
@@ -20,8 +21,8 @@ in
     service.image = "arion-base";
     service.build.context = "${../arion-image}";
     service.volumes = [
-      "/nix/store:/nix/store"
-      "${pkgs.buildEnv { name = "container-system-env"; paths = [ pkgs.bashInteractive pkgs.coreutils ]; }}:/run/system"
+      "${customNixRootPath}/nix/store:/nix/store"
+      "${customNixRootPath}${pkgs.buildEnv { name = "container-system-env"; paths = [ pkgs.bashInteractive pkgs.coreutils ]; }}:/run/system"
     ];
   };
 }


### PR DESCRIPTION
this fix allows to run tests in gitlab ci with cached /nix/store. E.g.

# scripts/setup-ci.sh

```sh
# Fix error
# error: while setting up the build environment: getting attributes of path '/etc/nsswitch.conf': No such file or directory
# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-424546457
echo 'hosts: files dns' > /etc/nsswitch.conf

# parallelize make
export MAKEFLAGS="-j$(nproc)"

cat > /etc/nix/nix.conf << EOL
# default from nixos image
sandbox = false

# Set default store path to store in cached folder
# this fill force "nix run" command to be executed inside chroot
store = $(pwd)/.mycache

# max-jobs is about the number of derivations that Nix will build in parallel
max-jobs = auto

# cores is about parallelism inside a derivation, e.g. what make -j will use
# 0 means use all available cores
cores = 0
EOL
```

# .gitlab-ci.yml

```yml
image: nixos/nix@sha256:85299d86263a3059cf19f419f9d286cc9f06d3c13146a8ebbb21b3437f598357

services:
  - docker:stable-dind

variables:
  # From https://docs.gitlab.com/ee/ci/docker/using_docker_build.html

  # When using dind service we need to instruct docker, to talk with the
  # daemon started inside of the service. The daemon is available with
  # a network connection instead of the default /var/run/docker.sock socket.
  #
  # The 'docker' hostname is the alias of the service container as described at
  # https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#accessing-the-services
  #
  # Note that if you're using Kubernetes executor, the variable should be set to
  # tcp://localhost:2375 because of how Kubernetes executor connects services
  # to the job container
  DOCKER_HOST: tcp://docker:2375/

  # When using dind, it's wise to use the overlayfs driver for
  # improved performance.
  DOCKER_DRIVER: overlay2

  # Required for git-crypt, use clone instead of fetch, because fetch runs git-crypt before it is installed
  GIT_STRATEGY: clone
  GIT_SUBMODULE_STRATEGY: recursive
  GIT_DEPTH: '1'
  COMPOSE_HTTP_TIMEOUT: 300 # default - 60

stages:
  - test

# TODO: how to populate cache even if test failed?
# TODO: how to not run test if it have already been run successfully?
db_tests:
  stage: test
  cache:
    key: "test00000" # to reset cache - change this key OR clear cache in project settings page
    paths:
      - .mycache # gitlab allows only cache dirs that are relative to project root OR /cache (created automatically)
  script:
    - source scripts/setup-ci.sh
    # "nix run" builds and runs run-db-tests in chroot, with $(pwd)/.mycache/nix/store mounted to /nix/store
    # but we provide "customNixRootPath" because docker volumes are not compatible with nix chroot, e.g.
    - nix run --file ./ci-tests/db-tests.nix --argstr customNixRootPath "$(pwd)/.mycache" --command run-db-tests
```

# ci-tests/db-tests.nix

```nix
{
  pkgs ? import ../nix/pkgs.nix,
  customNixRootPath ? "",
}:

with pkgs;

let

  docker-compose-spec = arionEvaluate {
    modules = [../docker/db_tests_ci.nix];
    inherit pkgs customNixRootPath;
  };

  docker-compose-file = docker-compose-spec.config.build.dockerComposeYaml;

  env = pkgs.buildEnv { name = "container-system-env"; paths = [ pkgs.bashInteractive pkgs.coreutils ]; };
in

writeScriptBin "run-db-tests" ''
  #!${stdenv.shell} -eux
  export PATH=${lib.makeBinPath [ utillinux bash coreutils docker docker-compose ]}

  docker version

  docker-compose -p myproject -f ${docker-compose-file} run --rm migrator /run/system/bin/sh -c '\
    waitforit -host=$HOST -port=$PORT -timeout=30 && \
    wait-for-postgres --dbname=postgres://$LOGIN:$PASSWORD@$HOST:$PORT/$DATABASE && \
    shmig -m /migrations -C always migrate'

  docker-compose -p myproject -f ${docker-compose-file} run --rm db_tests
  docker-compose -p myproject -f ${docker-compose-file} down --remove-orphans
''
```