### PR TITLE
Unset PYTHONPATH

### DIFF
--- a/src/arion
+++ b/src/arion
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Close off the python module search path
+#
+# Accepting directories from the environment into the search path
+# tends to break things. Docker Compose does not have a plugin
+# system as far as I can tell, so I don't expect this to break a
+# feature, but rather to make the program more robustly self-
+# contained.
+unset PYTHONPATH
+
 set -euo pipefail
 
 export PATH="@path@:$PATH"


### PR DESCRIPTION
Accepting directories from the environment into the search path
tends to break things. Docker Compose does not have a plugin
system as far as I can tell, so I don't expect this to break a
feature, but rather to make the program more robustly self-
contained.

Devil's advocate: this can be considered a bug in other programs or user behavior that sets PYTHONPATH. However, the errors are nasty and I don't think anyone wants to deal with that. The only reason to keep this is for some sort of monkey patching, which is better done as normal patching via overlays.
