### PR TITLE
Fixed faulty documentation

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -51,7 +51,7 @@ Add this module to your NixOS configuration:
 
 ```nix
 { ... }: {
-  environment.systemPackages = [ (import (builtins.fetchTarball https://github.com/hercules-ci/arion/tarball/master) {}) ];
+  environment.systemPackages = [ (import (builtins.fetchTarball https://github.com/hercules-ci/arion/tarball/master) {}).arion ];
   virtualisation.docker.enable = true;
   users.extraUsers.myuser.extraGroups = ["docker"];
 }


### PR DESCRIPTION
Fixed installation instructions for NixOS.
The previous version failed due to trying to add the set `{ arion; doc; tests; }` to the list `environment.systemPackages`.