### PR TITLE
Change deprecated types.string to types.str

### DIFF
--- a/src/nix/modules/composition/docker-compose.nix
+++ b/src/nix/modules/composition/docker-compose.nix
@@ -21,7 +21,7 @@ in
       description = "A derivation that produces a docker-compose.yaml file for this composition.";
     };
     build.dockerComposeYamlText = lib.mkOption {
-      type = lib.types.string;
+      type = lib.types.str;
       description = "The text of build.dockerComposeYaml.";
     };
     docker-compose.raw = lib.mkOption {

--- a/src/nix/modules/composition/host-environment.nix
+++ b/src/nix/modules/composition/host-environment.nix
@@ -15,7 +15,7 @@
     };
 
     host.nixStorePrefix = lib.mkOption {
-      type = lib.types.string;
+      type = lib.types.str;
       default = "";
       example = "/mnt/foo";
       description = ''


### PR DESCRIPTION
To avoid: "trace: warning: types.string is deprecated because it quietly concatenates strings"