### PR TITLE
[WIP] Support user-supplied Docker image archive derivations

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -38,6 +38,7 @@ Arion allows to compose containers with different granularity:
   * <<NixOS: run only one systemd service>>
   * <<NixOS: run full OS>>
   * <<Docker image from DockerHub>>
+  * <<Docker image tar archive>>
 
 == Installation
 
@@ -177,6 +178,53 @@ Describe containers using NixOS-style modules. There are a few options:
   };
 }
 ```
+
+==== Docker image tar archive
+
+`examples/custom-image/arion-compose.nix`:
+
+```nix
+{ pkgs, ... }:
+
+let
+  webRoot = "/www";
+
+  webserverImage = pkgs.dockerTools.buildLayeredImage {
+    name = "a-webserver";
+
+    config = {
+      Entrypoint = [
+        "${pkgs.darkhttpd}/bin/darkhttpd" webRoot
+      ];
+
+      Volumes = {
+        "${webRoot}" = {};
+      };
+    };
+  };
+in {
+  config.services = {
+
+    webserver = {
+      image.drv = webserverImage;
+      service.command = [ "--port" "8000" ];
+      service.ports = [
+        "8000:8000" # host:container
+      ];
+      service.volumes = [
+        "${webRoot}:${pkgs.nix.doc}/share/doc/nix/manual"
+      ];
+    };
+  };
+}
+```
+
+Note that `config.services.<service>.image.drv` accepts any derivation providing a
+https://docs.docker.com/engine/reference/commandline/image_load/[`docker image load`]able
+tar archive; it is not limited to derivations created with
+https://nixos.org/nixpkgs/manual/#ssec-pkgs-dockerTools-buildImage[`buildImage`]
+or https://nixos.org/nixpkgs/manual/#ssec-pkgs-dockerTools-buildLayeredImage[`buildLayeredImage`]
+from https://nixos.org/nixpkgs/manual/#sec-pkgs-dockerTools[`pkgs.dockerTools`].
 
 === Run
 

--- a/docs/modules/ROOT/partials/NixOSOptions.adoc
+++ b/docs/modules/ROOT/partials/NixOSOptions.adoc
@@ -179,6 +179,34 @@ Default::
 
 No Example:: {blank}
 
+== services.<name>.image.drv
+
+Docker image derivation to be `docker load`ed.
+
+By default, when `services.<name>.image.nixBuild` is enabled, this is
+the image produced using `services.<name>.image.command`,
+`services.<name>.image.contents`, and
+`services.<name>.image.rawConfig`.
+
+
+[discrete]
+=== details
+
+Type:: null or package
+Default::
++
+----
+{"_type":"literalExample","text":"pkgs.dockerTools.buildLayeredImage { ... };\n"}
+----
+
+
+Example::
++
+----
+{"_type":"literalExample","text":"let\n  myimage = pkgs.dockerTools.buildImage {\n    name = \"my-image\";\n    contents = [ pkgs.coreutils ];\n  };\nin\nconfig.services = {\n  myservice = {\n    image.drv = myimage;\n    # ...\n  };\n}\n"}
+----
+
+
 == services.<name>.image.name
 
 A human readable name for the docker image.

--- a/examples/custom-image/arion-compose.nix
+++ b/examples/custom-image/arion-compose.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+
+let
+  webRoot = "/www";
+
+  webserverImage = pkgs.dockerTools.buildLayeredImage {
+    name = "a-webserver";
+
+    config = {
+      Entrypoint = [
+        "${pkgs.darkhttpd}/bin/darkhttpd" webRoot
+      ];
+
+      Volumes = {
+        "${webRoot}" = {};
+      };
+    };
+  };
+in {
+  config.services = {
+
+    webserver = {
+      image.drv = webserverImage;
+      service.command = [ "--port" "8000" ];
+      service.ports = [
+        "8000:8000" # host:container
+      ];
+      service.volumes = [
+        "${webRoot}:${pkgs.nix.doc}/share/doc/nix/manual"
+      ];
+    };
+  };
+}

--- a/examples/custom-image/arion-pkgs.nix
+++ b/examples/custom-image/arion-pkgs.nix
@@ -1,0 +1,6 @@
+# Instead of pinning Nixpkgs, we can opt to use the one in NIX_PATH
+import <nixpkgs> {
+  # We specify the architecture explicitly. Use a Linux remote builder when
+  # calling arion from other platforms.
+  system = "x86_64-linux";
+}

--- a/src/nix/modules/service/image.nix
+++ b/src/nix/modules/service/image.nix
@@ -41,6 +41,14 @@ in
       type = nullOr package;
       description = ''
         Docker image derivation to be `docker load`ed.
+
+        By default, when `services.<name>.image.nixBuild` is enabled, this is
+        the image produced using `services.<name>.image.command`,
+        `services.<name>.image.contents`, and
+        `services.<name>.image.rawConfig`.
+      '';
+      defaultText = lib.literalExample ''
+        pkgs.dockerTools.buildLayeredImage { ... };
       '';
       internal = true;
     };
@@ -105,9 +113,27 @@ in
       description = ''
       '';
     };
+    image.drv = mkOption {
+      type = nullOr package;
+      inherit (options.build.image) description defaultText;
+      example = lib.literalExample ''
+        let
+          myimage = pkgs.dockerTools.buildImage {
+            name = "my-image";
+            contents = [ pkgs.coreutils ];
+          };
+        in
+        config.services = {
+          myservice = {
+            image.drv = myimage;
+            # ...
+          };
+        }
+      '';
+    };
   };
   config = {
-    build.image = builtImage;
+    build.image = config.image.drv or builtImage;
     build.imageName = config.build.image.imageName;
     build.imageTag =
                  if config.build.image.imageTag != ""

--- a/tests/arion-test/default.nix
+++ b/tests/arion-test/default.nix
@@ -31,6 +31,7 @@ in
       # Pre-build the image because we don't want to build the world
       # in the vm.
       (preEval [ ../../examples/minimal/arion-compose.nix ]).config.out.dockerComposeYaml
+      (preEval [ ../../examples/custom-image/arion-compose.nix ]).config.out.dockerComposeYaml
       (preEval [ ../../examples/full-nixos/arion-compose.nix ]).config.out.dockerComposeYaml
       (preEval [ ../../examples/nixos-unit/arion-compose.nix ]).config.out.dockerComposeYaml
       pkgs.stdenv
@@ -53,6 +54,7 @@ in
     };
 
     $makeSubtest->("minimal", "${../../examples/minimal}");
+    $makeSubtest->("custom-image", "${../../examples/custom-image}");
     $makeSubtest->("full-nixos", "${../../examples/full-nixos}", sub {
       $machine->succeed("cd work && export NIX_PATH=nixpkgs='${pkgs.path}' && (echo 'nix run -f ~/h/arion arion -c arion exec webserver'; echo 'target=world; echo Hello \$target'; echo exit) | script /dev/null | grep 'Hello world'");
     });


### PR DESCRIPTION
First of all, thank you for this fantastic utility!  I am so pleased to be able to describe Docker Compose environments using Nix instead of YAML :)

This PR introduces support for user-supplied Docker image archives via the attribute `service.<name>.image.drv`.  The idea is that users can invoke `dockerTools.buildImage`, `dockerTools.buildLayeredImage`, or any other means of constructing a derivation that evaluates to a Docker image archive, then hand this off to Arion for use in the Compose environment.

This permits Arion users to exercise fine-grained control over their Docker images, even finer than what is possible with `service.<name>.image.rawConfig`.  Additionally, it makes it easier to manipulate images separately from Arion (_e.g._, `docker load`ing an archive constructed with a `dockerTools` function, then `docker push`ing it to some registry).

I am a Nix neophyte, and anticipate that I've committed any number of misjudgments here.  Some questions that spring to mind:

1. Is `service.<name>.image.drv` a good name?  Maybe there's something more descriptive/straightforward?
2. Is stronger type-checking warranted?  Right now, `service.<name>.image.drv` accepts either `null` or any derivation whatever, regardless of whether it evaluates to a Docker image archive when built.  This seems fine for an option marked `internal`, but maybe not one intended for public consumption.  Checking for the AFAIK-`dockerTools`-specific `imageName` or `passthru.imageTag` is probably too stringent; maybe there are sentinels of Docker imagehood not specific to `dockerTools`?  OTOH maybe `docker load`-time errors are acceptable here, as they are basically analogous to the runtime errors that would occur upon mis-specifying `service.<name>.service.name`?
3. Is there a better way to handle constructing a default image derivation than `build.image = config.image.drv or builtImage`?  It does not feel DRY to have both `build.image` and `image.drv`, but I couldn't find a straightforward way to remove the duplication.  In particular, the following construct:
```nix
{
  image.drv = mkOption {
    type = nullOr package;
    default = builtImage;
  };
}
```
led to the error:
```
$ env -u NIX_PATH nix-build --show-trace ./nix/ci.nix 
error: while evaluating the attribute 'text' of the derivation 'agent-options' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/pkgs/build-support/trivial-builders.nix:7:14:
while evaluating the attribute 'optionsAsciiDoc' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/nixos/lib/make-options-doc/default.nix:132:3:
while evaluating anonymous function at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:234:10, called from undefined position:
while evaluating 'singleAsciiDoc' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/nixos/lib/make-options-doc/default.nix:94:26, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:234:16:
while evaluating the attribute 'default' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/nixos/lib/make-options-doc/default.nix:37:44:
while evaluating 'substFunction' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/nixos/lib/make-options-doc/default.nix:28:19, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/nixos/lib/make-options-doc/default.nix:37:54:
while evaluating the attribute 'default' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/options.nix:154:44:
while evaluating 'scrubOptionValue' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/options.nix:173:22, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/options.nix:154:54:
while evaluating 'isDerivation' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:305:18, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/options.nix:174:8:
while evaluating the attribute 'default' at /var/lib/hercules-ci-agent/work/eval-75444b67e5c0aab9/primary/tomeon-arion-2afdefd/src/nix/modules/service/image.nix:42:7:
while evaluating the module argument `pkgs' in "/var/lib/hercules-ci-agent/work/eval-75444b67e5c0aab9/primary/tomeon-arion-2afdefd/src/nix/modules/service/image.nix":
while evaluating the attribute '_module.args.pkgs' at undefined position:
while evaluating anonymous function at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:75:45, called from undefined position:
while evaluating the attribute 'value' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:336:9:
while evaluating the option `services.<name>._module.args':
while evaluating the attribute 'mergedValue' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:368:5:
while evaluating anonymous function at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:368:32, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:368:19:
while evaluating 'merge' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/types.nix:283:20, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:371:8:
while evaluating 'filterAttrs' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:124:23, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/types.nix:284:35:
while evaluating anonymous function at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:125:29, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:125:18:
while evaluating anonymous function at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/types.nix:284:51, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:125:62:
while evaluating the attribute 'pkgs' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:344:7:
while evaluating anonymous function at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/types.nix:284:86, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/attrsets.nix:344:15:
while evaluating the attribute 'optionalValue' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:375:5:
while evaluating the attribute 'values' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:362:9:
while evaluating anonymous function at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:358:19, called from /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:358:14:
while evaluating the attribute 'value._type' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:454:73:
while evaluating the attribute 'value.content' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:515:14:
while evaluating the attribute 'pkgs' at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:162:9:
while evaluating the module argument `pkgs' in "/var/lib/hercules-ci-agent/work/eval-75444b67e5c0aab9/primary/tomeon-arion-2afdefd/src/nix/modules/composition/docker-compose.nix":
while evaluating the attribute '_module.args.pkgs' at undefined position:
attribute 'pkgs' missing, at /nix/store/g7is268z0zj1qfdvm4vlvihcsvgfplc4-source/lib/modules.nix:163:28
```

---

I've also included a fix for an issue in the `nixosTest` suite: the `work` directory containing `arion-pkgs.nix` and `arion-compose.nix` wasn't being properly cleaned up, leading to all test cases subsequent to the first (`minimal`) failing to run (more precisely, all test cases subsequent to the first simply re-ran the first).

Happy to put this changeset in a separate PR if you'd prefer.

---

Thanks in advance for your consideration!