### PR TITLE
allow all string compatible types for service.environment

### DIFF
--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -8,7 +8,7 @@
 
 let
   inherit (lib) mkOption types;
-  inherit (types) listOf nullOr attrsOf str either int bool;
+  inherit (types) attrs attrsOf bool either int list listOf nullOr oneOf path str;
 
   link = url: text:
     ''link:${url}[${text}]'';
@@ -82,7 +82,7 @@ in
       description = dockerComposeKitchenSink;
     };
     service.environment = mkOption {
-      type = attrsOf (either str int);
+      type = attrsOf (oneOf [ str path attrs int list bool null ]);
       default = {};
       description = dockerComposeRef "environment";
     };


### PR DESCRIPTION
This change allows to pass more types to `service.environment`.
Previous to this PR, the following example would have failed:
```nix
{ service.environment.PYTHONPATH = ./.; }
```

To fix this, I added all types to the allow list which can be converted to string according to the documentation of the toString function: https://github.com/NixOS/nix/blob/cbb9862cd9008f7e34d9367b5a4fb520ee0ba351/src/libexpr/primops.cc#L2983