### PR TITLE
Add name option for project/composition name

### DIFF
--- a/arion-compose.cabal
+++ b/arion-compose.cabal
@@ -49,6 +49,7 @@ library
   exposed-modules:     Arion.Nix
                        Arion.Aeson
                        Arion.DockerCompose
+                       Arion.ExtendedInfo
                        Arion.Images
                        Arion.Services
   other-modules:       Paths_arion_compose

--- a/docs/modules/ROOT/partials/NixOSOptions.adoc
+++ b/docs/modules/ROOT/partials/NixOSOptions.adoc
@@ -70,26 +70,6 @@ No Default:: {blank}
 
 No Example:: {blank}
 
-== name
-
-Name of the project.
-
-See link:https://docs.docker.com/compose/reference/envvars/#compose_project_name[COMPOSE_PROJECT_NAME]
-
-
-[discrete]
-=== details
-
-Type:: null or string
-Default::
-+
-----
-null
-----
-
-
-No Example:: {blank}
-
 == out.dockerComposeYaml
 
 A derivation that produces a docker-compose.yaml file for this composition.
@@ -124,6 +104,26 @@ The text of out.dockerComposeYaml.
 Type:: string
 No Default:: {blank}
 Read Only:: {blank}
+No Example:: {blank}
+
+== project.name
+
+Name of the project.
+
+See link:https://docs.docker.com/compose/reference/envvars/#compose_project_name[COMPOSE_PROJECT_NAME]
+
+
+[discrete]
+=== details
+
+Type:: null or string
+Default::
++
+----
+null
+----
+
+
 No Example:: {blank}
 
 == services

--- a/docs/modules/ROOT/partials/NixOSOptions.adoc
+++ b/docs/modules/ROOT/partials/NixOSOptions.adoc
@@ -70,6 +70,26 @@ No Default:: {blank}
 
 No Example:: {blank}
 
+== name
+
+Name of the project.
+
+See link:https://docs.docker.com/compose/reference/envvars/#compose_project_name[COMPOSE_PROJECT_NAME]
+
+
+[discrete]
+=== details
+
+Type:: null or string
+Default::
++
+----
+null
+----
+
+
+No Example:: {blank}
+
 == out.dockerComposeYaml
 
 A derivation that produces a docker-compose.yaml file for this composition.

--- a/examples/minimal/arion-compose.nix
+++ b/examples/minimal/arion-compose.nix
@@ -1,5 +1,6 @@
 { pkgs, ... }:
 {
+  config.name = "webapp";
   config.services = {
 
     webserver = {

--- a/examples/minimal/arion-compose.nix
+++ b/examples/minimal/arion-compose.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 {
-  config.name = "webapp";
+  config.project.name = "webapp";
   config.services = {
 
     webserver = {

--- a/src/haskell/exe/Main.hs
+++ b/src/haskell/exe/Main.hs
@@ -10,7 +10,7 @@ import           Arion.Aeson
 import           Arion.Images (loadImages)
 import qualified Arion.DockerCompose as DockerCompose
 import           Arion.Services (getDefaultExec)
-import           Arion.ExtendedInfo (loadExtendedInfoFromPath, ExtendedInfo(images, name))
+import           Arion.ExtendedInfo (loadExtendedInfoFromPath, ExtendedInfo(images, projectName))
 
 import Options.Applicative
 import Control.Monad.Fail
@@ -155,7 +155,7 @@ callDC cmd dopts shouldLoadImages path = do
   when shouldLoadImages $ loadImages (images extendedInfo)
   let firstOpts =
         do
-          n <- toList (name extendedInfo)
+          n <- toList (projectName extendedInfo)
           ["--project-name", n]
   DockerCompose.run DockerCompose.Args
     { files = [path]

--- a/src/haskell/lib/Arion/ExtendedInfo.hs
+++ b/src/haskell/lib/Arion/ExtendedInfo.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-
+
+Parses the x-arion field in the generated compose file.
+
+-}
+module Arion.ExtendedInfo where
+
+import Prelude()
+import Protolude
+import Data.Aeson as Aeson
+import Arion.Aeson
+import Control.Lens
+import Data.Aeson.Lens
+
+data Image = Image
+  { image :: Maybe Text -- ^ image tar.gz file path
+  , imageExe :: Maybe Text -- ^ path to exe producing image tar
+  , imageName :: Text
+  , imageTag :: Text
+  } deriving (Eq, Show, Generic, Aeson.ToJSON, Aeson.FromJSON)
+
+data ExtendedInfo = ExtendedInfo {
+    name :: Maybe Text,
+    images :: [Image]
+  } deriving (Eq, Show)
+
+loadExtendedInfoFromPath :: FilePath -> IO ExtendedInfo
+loadExtendedInfoFromPath fp = do
+  v <- decodeFile fp
+  pure ExtendedInfo {
+    -- TODO: use aeson derived instance?
+    name = v ^? key "x-arion" . key "name" . _String,
+    images = (v :: Aeson.Value) ^.. key "x-arion" . key "images" . _Array . traverse . _JSON
+  }

--- a/src/haskell/lib/Arion/ExtendedInfo.hs
+++ b/src/haskell/lib/Arion/ExtendedInfo.hs
@@ -23,7 +23,7 @@ data Image = Image
   } deriving (Eq, Show, Generic, Aeson.ToJSON, Aeson.FromJSON)
 
 data ExtendedInfo = ExtendedInfo {
-    name :: Maybe Text,
+    projectName :: Maybe Text,
     images :: [Image]
   } deriving (Eq, Show)
 
@@ -32,6 +32,6 @@ loadExtendedInfoFromPath fp = do
   v <- decodeFile fp
   pure ExtendedInfo {
     -- TODO: use aeson derived instance?
-    name = v ^? key "x-arion" . key "name" . _String,
+    projectName = v ^? key "x-arion" . key "project" . key "name" . _String,
     images = (v :: Aeson.Value) ^.. key "x-arion" . key "images" . _Array . traverse . _JSON
   }

--- a/src/haskell/lib/Arion/Images.hs
+++ b/src/haskell/lib/Arion/Images.hs
@@ -8,38 +8,23 @@ module Arion.Images
 import Prelude()
 import Protolude hiding (to)
 
-import qualified Data.Aeson as Aeson
-import           Arion.Aeson (decodeFile)
 import qualified System.Process as Process
 import qualified Data.Text as T
 
-import Control.Lens
-import Data.Aeson.Lens
-
-data Image = Image
-  { image :: Maybe Text -- ^ image tar.gz file path
-  , imageExe :: Maybe Text -- ^ path to exe producing image tar
-  , imageName :: Text
-  , imageTag :: Text
-  } deriving (Generic, Aeson.ToJSON, Aeson.FromJSON, Show)
+import Arion.ExtendedInfo (Image(..))
 
 type TaggedImage = Text
 
 -- | Subject to change
-loadImages :: FilePath -> IO ()
-loadImages fp = do
-
-  v <- decodeFile fp
+loadImages :: [Image] -> IO ()
+loadImages requestedImages = do
 
   loaded <- getDockerImages
 
   let
-    images :: [Image]
-    images = (v :: Aeson.Value) ^.. key "x-arion" . key "images" . _Array . traverse . _JSON
-
     isNew i = (imageName i <> ":" <> imageTag i) `notElem` loaded
 
-  traverse_ loadImage . filter isNew $ images
+  traverse_ loadImage . filter isNew $ requestedImages
 
 loadImage :: Image -> IO ()
 loadImage (Image { image = Just imgPath, imageName = name }) =

--- a/src/haskell/testdata/Arion/NixSpec/arion-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-compose.json
@@ -37,7 +37,9 @@
                 "imageTag": "<HASH>"
             }
         ],
-        "name": null,
+        "project": {
+            "name": null
+        },
         "serviceInfo": {
             "webserver": {
                 "defaultExec": [

--- a/src/haskell/testdata/Arion/NixSpec/arion-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-compose.json
@@ -37,6 +37,7 @@
                 "imageTag": "<HASH>"
             }
         ],
+        "name": null,
         "serviceInfo": {
             "webserver": {
                 "defaultExec": [

--- a/src/haskell/testdata/docker-compose-example.json
+++ b/src/haskell/testdata/docker-compose-example.json
@@ -30,7 +30,9 @@
         "imageTag": "xr4ljmz3qfcwlq9rl4mr4qdrzw93rl70"
       }
     ],
-    "name": null,
+    "project": {
+      "name": null
+    },
     "serviceInfo": {
       "webserver": {
         "defaultExec": [

--- a/src/haskell/testdata/docker-compose-example.json
+++ b/src/haskell/testdata/docker-compose-example.json
@@ -30,6 +30,7 @@
         "imageTag": "xr4ljmz3qfcwlq9rl4mr4qdrzw93rl70"
       }
     ],
+    "name": null,
     "serviceInfo": {
       "webserver": {
         "defaultExec": [

--- a/src/nix/modules.nix
+++ b/src/nix/modules.nix
@@ -4,4 +4,5 @@
     ./modules/composition/images.nix
     ./modules/composition/service-info.nix
     ./modules/composition/arion-base-image.nix
+    ./modules/composition/composition.nix
 ]

--- a/src/nix/modules/composition/composition.nix
+++ b/src/nix/modules/composition/composition.nix
@@ -8,7 +8,7 @@ let
 in
 {
   options = {
-    name = mkOption {
+    project.name = mkOption {
       description = ''
         Name of the project.
 
@@ -19,6 +19,6 @@ in
     };
   };
   config = {
-    docker-compose.extended.name = config.name;
+    docker-compose.extended.project.name = config.project.name;
   };
 }

--- a/src/nix/modules/composition/composition.nix
+++ b/src/nix/modules/composition/composition.nix
@@ -1,0 +1,24 @@
+{ config, lib, ... }:
+let
+  inherit (lib) types mkOption;
+
+  link = url: text:
+    ''link:${url}[${text}]'';
+
+in
+{
+  options = {
+    name = mkOption {
+      description = ''
+        Name of the project.
+
+        See ${link "https://docs.docker.com/compose/reference/envvars/#compose_project_name" "COMPOSE_PROJECT_NAME"}
+      '';
+      type = types.nullOr types.str;
+      default = null;
+    };
+  };
+  config = {
+    docker-compose.extended.name = config.name;
+  };
+}


### PR DESCRIPTION
Closes #54 

Example:

```
{ pkgs, ... }:
{
  config.name = "webapp";
  config.services = {

    webserver = {
# ...
```

```
CONTAINER ID        IMAGE                                         COMMAND                   CREATED             STATUS                      PORTS                                             NAMES
b596d3b70cbc        arion-base:0mgpf3nxfmkxg0nb17r6x8vpg4g52a0s   "sh -c 'cd \"$WEB_ROO…"   6 minutes ago       Exited (0) 5 minutes ago                                                      webapp_webserver_1
```