### PR TITLE
Add service.dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* Support `service.dns`, for overriding the DNS servers used by containers.
+
 * Support `service.labels`, which is useful for autodiscovery among other things.
 
 * Add a tested example for Traefik with label-based routing.

--- a/docs/modules/ROOT/partials/NixOSOptions.adoc
+++ b/docs/modules/ROOT/partials/NixOSOptions.adoc
@@ -525,6 +525,28 @@ Default::
 
 No Example:: {blank}
 
+== services.<name>.service.dns
+
+See link:https://docs.docker.com/compose/compose-file/#dns[Docker Compose#dns]
+
+[discrete]
+=== details
+
+Type:: list of strings
+Default::
++
+----
+[]
+----
+
+
+Example::
++
+----
+["8.8.8.8","8.8.4.4"]
+----
+
+
 == services.<name>.service.entrypoint
 
 See link:https://docs.docker.com/compose/compose-file/#entrypoint[Docker Compose#entrypoint]

--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -115,6 +115,12 @@ in
         ${dockerComposeRef "devices"}
       '';
     };
+    service.dns = mkOption {
+      type = listOf str;
+      default = [];
+      example = [ "8.8.8.8" "8.8.4.4" ];
+      description = dockerComposeRef "dns";
+    };
     service.labels = mkOption {
       type = attrsOf str;
       default = {};
@@ -258,6 +264,8 @@ in
     inherit (config.service) extra_hosts;
   } // lib.optionalAttrs (config.service.hostname != null) {
     inherit (config.service) hostname;
+  } // lib.optionalAttrs (config.service.dns != []) {
+    inherit (config.service) dns;
   } // lib.optionalAttrs (config.service.labels != {}) {
     inherit (config.service) labels;
   } // lib.optionalAttrs (config.service.links != []) {


### PR DESCRIPTION
Exposes the the [`dns` option](https://docs.docker.com/compose/compose-file/compose-file-v3/#dns). The spec says this can be a list of strings or a single string (for a single DNS resolver), but no functionality is lost by restricting it to the former so I have done so for simplicity's case.