### PR TITLE
Add service.healthcheck and extend service.depends_on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for Arion
 
+## Next
+
+### Changed
+
+* Healthcheck-based dependencies in `service.depends_on`.
+
+### Added
+
+* Support `service.healthcheck` for defining custom healthchecks.
+
 ## 0.1.3.0 -- 2020-05-03
 
 ### Changed

--- a/docs/modules/ROOT/partials/NixOSOptions.adoc
+++ b/docs/modules/ROOT/partials/NixOSOptions.adoc
@@ -514,7 +514,7 @@ See link:https://docs.docker.com/compose/compose-file/#depends_on[Docker Compose
 [discrete]
 === details
 
-Type:: list of strings
+Type:: list of strings or attribute set of attribute set of stringss
 Default::
 +
 ----
@@ -667,6 +667,89 @@ Default::
 
 
 No Example:: {blank}
+
+== services.<name>.service.healthcheck.interval
+
+See link:https://docs.docker.com/compose/compose-file/#healthcheck[Docker Compose#healthcheck]
+
+[discrete]
+=== details
+
+Type:: string
+Default::
++
+----
+"30s"
+----
+
+
+Example::
++
+----
+"1m"
+----
+
+
+== services.<name>.service.healthcheck.retries
+
+See link:https://docs.docker.com/compose/compose-file/#healthcheck[Docker Compose#healthcheck]
+
+[discrete]
+=== details
+
+Type:: signed integer
+Default::
++
+----
+3
+----
+
+
+No Example:: {blank}
+
+== services.<name>.service.healthcheck.test
+
+See link:https://docs.docker.com/compose/compose-file/#healthcheck[Docker Compose#healthcheck]
+
+[discrete]
+=== details
+
+Type:: null or list of strings
+Default::
++
+----
+null
+----
+
+
+Example::
++
+----
+["CMD","pg_isready"]
+----
+
+
+== services.<name>.service.healthcheck.timeout
+
+See link:https://docs.docker.com/compose/compose-file/#healthcheck[Docker Compose#healthcheck]
+
+[discrete]
+=== details
+
+Type:: string
+Default::
++
+----
+"30s"
+----
+
+
+Example::
++
+----
+"10s"
+----
+
 
 == services.<name>.service.hostStoreAsReadOnly
 

--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -101,9 +101,32 @@ in
       description = dockerComposeRef "container_name";
     };
     service.depends_on = mkOption {
-      type = listOf str;
+      type = either (listOf str) (attrsOf (attrsOf str));
       default = [];
       description = dockerComposeRef "depends_on";
+    };
+    service.healthcheck.test = mkOption {
+      type = nullOr (listOf str);
+      default = null;
+      example = [ "CMD" "pg_isready" ];
+      description = dockerComposeRef "healthcheck";
+    };
+    service.healthcheck.interval = mkOption {
+      type = str;
+      default = "30s";
+      example = "1m";
+      description = dockerComposeRef "healthcheck";
+    };
+    service.healthcheck.timeout = mkOption {
+      type = str;
+      default = "30s";
+      example = "10s";
+      description = dockerComposeRef "healthcheck";
+    };
+    service.healthcheck.retries = mkOption {
+      type = int;
+      default = 3;
+      description = dockerComposeRef "healthcheck";
     };
     service.devices = mkOption {
       type = listOf str;
@@ -250,6 +273,8 @@ in
     inherit (config.service) container_name;
   } // lib.optionalAttrs (config.service.depends_on != []) {
     inherit (config.service) depends_on;
+  } // lib.optionalAttrs (config.service.healthcheck.test != null) {
+    inherit (config.service) healthcheck;
   } // lib.optionalAttrs (config.service.devices != []) {
     inherit (config.service) devices;
   } // lib.optionalAttrs (config.service.entrypoint != null) {


### PR DESCRIPTION
Add option to define custom health checks for services, and extend `depends_on` so it can also include `<service>.condition` field for conditions based on health checks.