### PR TITLE
Support for docker rootless

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -28,7 +28,7 @@ let
       _systemd = mkOption { internal = true; };
     };
     config =
-      let config = {
+      let service = {
         wantedBy = [ "multi-user.target" ];
         after = [ "sockets.target" ];
 
@@ -37,7 +37,7 @@ let
           cfg.docker.client.package
         ];
         environment.ARION_PREBUILT = config.settings.out.dockerComposeYaml;
-        # environment.DOCKER_HOST = "unix://$XDG_RUNTIME_DIR/docker.sock";
+        environment.DOCKER_HOST = mkIf (cfg.backend == "docker-rootless") "unix:///run/user/1000/docker.sock";
         script = ''
           echo 1>&2 "docker compose file: $ARION_PREBUILT"
           arion --prebuilt-file "$ARION_PREBUILT" up
@@ -45,9 +45,9 @@ let
       };
     in
       if cfg.backend == "docker-rootless" then
-        { _systemd.user.services."arion-${name}" = config; }
+        { _systemd.user.services."arion-${name}" = service; }
       else
-        { _systemd.services."arion-${name}" = config; };
+        { _systemd.services."arion-${name}" = service; };
   };
 
   arionSettingsType = name:


### PR DESCRIPTION
First, I did not see any contribution guide, therefore I am just opening this PR. I hope that's ok.

Since version 22.05 NixOS has support for rootless docker ([manual](https://nixos.wiki/wiki/Docker), [docs](https://search.nixos.org/options?query=virtualisation.docker.rootless)).
Therefore, I want to add support for it to this great project.

This is currently not working, yet. But I do not know enough about the internals of arion to fix it.
I get some weird docker error; something about certificates (please try it out and see for yourselves).
Also, I am not sure if adding the `DOCKER_HOST` variable is necessary or if there is a better way (For me the option `docker.rootless.setSocketVariable` seems to not work)
I am sorry that I cannot be of more help here.

I hope this PR is welcome and is a starting point to bring rootless docker support to this project.