### PR TITLE
Disable DHCP in full-nixos example

### DIFF
--- a/examples/full-nixos/arion-compose.nix
+++ b/examples/full-nixos/arion-compose.nix
@@ -3,6 +3,7 @@
   services.webserver = { pkgs, lib, ... }: {
     nixos.useSystemd = true;
     nixos.configuration.boot.tmpOnTmpfs = true;
+    nixos.configuration.networking.useDHCP = false;
     nixos.configuration.services.nginx.enable = true;
     nixos.configuration.services.nginx.virtualHosts.localhost.root = "${pkgs.nix.doc}/share/doc/nix/manual";
     nixos.configuration.services.nscd.enable = false;


### PR DESCRIPTION
Hello.

In full-nixos example DHCP is not disabled, and it breaks network inside container.
