### PR TITLE
Improve service.networks

### DIFF
--- a/examples/traefik/arion-compose.nix
+++ b/examples/traefik/arion-compose.nix
@@ -10,6 +10,17 @@
  */
 { lib, pkgs, ... }: {
   config.project.name = "traefik";
+  config.networks = {
+    traefik-custom = {
+      name = "traefik-custom";
+      ipam = {
+        config = [{
+          subnet = "172.32.0.0/16";
+          gateway = "172.32.0.1";
+        }];
+      };
+    };
+  };
   config.services = {
     traefik = {
       image.command = [
@@ -24,6 +35,7 @@
         stop_signal = "SIGINT";
         ports = [ "80:80" "8080:8080" ];
         volumes = [ "/var/run/docker.sock:/var/run/docker.sock:ro" ];
+        networks = [ "traefik-custom" ];
       };
     };
 
@@ -34,14 +46,17 @@
         ${pkgs.python3}/bin/python -m http.server
       ''}"];
       service.container_name = "simple-service";
-      service.ports = [
-        "8000:8000" # host:container
-      ];
       service.stop_signal = "SIGINT";
       service.labels = {
         "traefik.enable" = "true";
         "traefik.http.routers.nix-docs.rule" = "Host(`nix-docs.localhost`)";
         "traefik.http.routers.nix-docs.entrypoints" = "web";
+        "traefik.http.services.nix-docs.loadBalancer.server.port" = "8000";
+      };
+      service.networks = {
+        traefik-custom = {
+          ipv4_address = "172.32.0.5";
+        };
       };
     };
   };

--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -253,11 +253,36 @@ in
       default = null;
       description = serviceRef "network_mode";
     };
-    service.networks = mkOption {
-      type = nullOr (listOf types.str);
-      default = null;
-      description = serviceRef "networks";
-    };
+    service.networks =
+      let
+        networksModule = submodule ({ config, options, ...}: {
+          options = {
+            _out = mkOption {
+              internal = true;
+              readOnly = true;
+              default = lib.mapAttrs (k: opt: opt.value) (lib.filterAttrs (_: opt: opt.isDefined) { inherit (options) aliases ipv4_address ipv6_address; });
+            };
+            aliases = mkOption {
+              type = listOf str;
+              description = serviceRef "aliases";
+              default = [ ];
+            };
+            ipv4_address = mkOption {
+              type = str;
+              description = serviceRef "ipv4_address-ipv6_address";
+            };
+            ipv6_address = mkOption {
+              type = str;
+              description = serviceRef "ipv4_address-ipv6_address";
+            };
+          };
+        });
+      in
+      mkOption {
+        type = either (listOf str) (attrsOf networksModule);
+        default = [];
+        description = serviceRef "networks";
+      };
     service.stop_signal = mkOption {
       type = nullOr str;
       default = null;
@@ -337,8 +362,10 @@ in
     inherit (config.service) privileged;
   } // lib.optionalAttrs (config.service.network_mode != null) {
     inherit (config.service) network_mode;
-  } // lib.optionalAttrs (config.service.networks != null) {
-    inherit (config.service) networks;
+  } // lib.optionalAttrs (config.service.networks != [] && config.service.networks != {}) {
+    networks =
+      if (builtins.isAttrs config.service.networks) then builtins.mapAttrs (_: v: v._out) config.service.networks
+      else config.service.networks;
   } // lib.optionalAttrs (config.service.restart != null) {
     inherit (config.service) restart;
   } // lib.optionalAttrs (config.service.stop_signal != null) {

--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -260,7 +260,7 @@ in
             _out = mkOption {
               internal = true;
               readOnly = true;
-              default = lib.mapAttrs (k: opt: opt.value) (lib.filterAttrs (_: opt: opt.isDefined) { inherit (options) aliases ipv4_address ipv6_address; });
+              default = lib.mapAttrs (k: opt: opt.value) (lib.filterAttrs (_: opt: opt.isDefined) { inherit (options) aliases ipv4_address ipv6_address link_local_ips priority; });
             };
             aliases = mkOption {
               type = listOf str;
@@ -274,6 +274,14 @@ in
             ipv6_address = mkOption {
               type = str;
               description = serviceRef "ipv4_address-ipv6_address";
+            };
+            link_local_ips = mkOption {
+              type = listOf str;
+              description = serviceRef "link_local_ips";
+            };
+            priority = mkOption {
+              type = int;
+              description = serviceRef "priority";
             };
           };
         });


### PR DESCRIPTION
This PR adds more options to `service.networks`, according to the [spec](https://docs.docker.com/compose/compose-file/compose-file-v3/#networks) it exposes:
- `aliases`
- `ipv4_address`
- `ipv6_address`

A more complex example using these options is added, by modifying the existing `traefik` example.
I wasn't able to run the tests locally on my non-NixOS machine, but from what I can see, it just tests if the host is available. 
That is still true and works, I checked by running `arion up` from the `examples/traefik` folder.