### PR TITLE
Use Compose Spec links in docs

### DIFF
--- a/src/nix/lib.nix
+++ b/src/nix/lib.nix
@@ -3,11 +3,13 @@ let
 
   link = url: text: ''[${text}](${url})'';
 
+  composeSpecRev = "55b450aee50799a2f33cc99e1d714518babe305e";
+
   serviceRef = fragment:
-    ''See ${link "https://docs.docker.com/compose/compose-file/05-services/#${fragment}" "Docker Compose Services #${fragment}"}'';
+    ''See ${link "https://github.com/compose-spec/compose-spec/blob/${composeSpecRev}/05-services.md#${fragment}" "Compose Spec Services #${fragment}"}'';
 
   networkRef = fragment:
-    ''See ${link "https://docs.docker.com/compose/compose-file/06-networks/#${fragment}" "Docker Compose Network #${fragment}"}'';
+    ''See ${link "https://github.com/compose-spec/compose-spec/blob/${composeSpecRev}/06-networks.md${fragment}" "Compose Spec Networks #${fragment}"}'';
 
 in
 {

--- a/src/nix/lib.nix
+++ b/src/nix/lib.nix
@@ -9,7 +9,7 @@ let
     ''See ${link "https://github.com/compose-spec/compose-spec/blob/${composeSpecRev}/05-services.md#${fragment}" "Compose Spec Services #${fragment}"}'';
 
   networkRef = fragment:
-    ''See ${link "https://github.com/compose-spec/compose-spec/blob/${composeSpecRev}/06-networks.md${fragment}" "Compose Spec Networks #${fragment}"}'';
+    ''See ${link "https://github.com/compose-spec/compose-spec/blob/${composeSpecRev}/06-networks.md#${fragment}" "Compose Spec Networks #${fragment}"}'';
 
 in
 {


### PR DESCRIPTION
Since `arion` supports both `docker` and `podman` as a backend, I thought docs might point to a generic `compose-spec` because both of these backends implement it: https://github.com/compose-spec/compose-spec#implementations


I tested the docs with: 
```Shell
less $(nix build .#generated-option-doc-arion --print-out-paths)
```

I didn't test the validity of all the links. I clicked a couple and ensured the general way of constructing the link worked.