### PR TITLE
Remove base upper bound

### DIFF
--- a/arion-compose.cabal
+++ b/arion-compose.cabal
@@ -30,7 +30,7 @@ source-repository head
   location: https://github.com/hercules-ci/arion
 
 common common
-  build-depends:     base >=4.12.0.0 && <4.17
+  build-depends:     base >=4.12.0.0 && <4.99
                    , aeson >=2
                    , aeson-pretty
                    , async

--- a/run-arion-via-nix
+++ b/run-arion-via-nix
@@ -3,4 +3,4 @@
 # For manual testing of a hacked arion built via Nix.
 # Works when called from outside the project directory.
 
-exec nix run -f "$(dirname ${BASH_SOURCE[0]})" arion -c arion "$@"
+exec nix run -f "$(dirname ${BASH_SOURCE[0]})" arion "$@"


### PR DESCRIPTION
Having to bump base is causing more breakage than what it supposedly fixes.
