### PR TITLE
fix(modules/service/nixos-init): Use `boot.tmp.useTmpfs` option instead of `boot.tmpOnTmpfs`

### DIFF
--- a/src/nix/modules/service/nixos-init.nix
+++ b/src/nix/modules/service/nixos-init.nix
@@ -39,7 +39,7 @@ in
     service.tmpfs = [
       "/run"          # noexec is fine because exes should be symlinked from elsewhere anyway
       "/run/wrappers" # noexec breaks this intentionally
-    ] ++ lib.optional (config.nixos.evaluatedConfig.boot.tmpOnTmpfs) "/tmp:exec,mode=777";
+    ] ++ lib.optional (config.nixos.evaluatedConfig.boot.tmp.useTmpfs) "/tmp:exec,mode=777";
 
     service.stop_signal = "SIGRTMIN+3";
     service.tty = true;


### PR DESCRIPTION
This change fixes the following warning:

```
trace: Obsolete option `boot.tmpOnTmpfs' is used. It was renamed to `boot.tmp.useTmpfs'.
```

This option was renamed in this PR:
https://github.com/NixOS/nixpkgs/pull/204534