### PR TITLE
fix link to demo todomvc

### DIFF
--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -1,4 +1,4 @@
 
 # todomvc
 
-This is the most full-featured example of a project. It's a [demo/template repo in its own right.](https://github.com/nix-community/todomvc-nix/tree/master/deploy/arion).
+This is the most full-featured example of a project. It's a [demo/template repo in its own right.](https://github.com/nix-community/todomvc-nix).


### PR DESCRIPTION
Replace https://github.com/nix-community/todomvc-nix/tree/master/deploy/arion with https://github.com/nix-community/todomvc-nix