### PR TITLE
Add configurable systemd service name to NixOS module

### DIFF
--- a/docs/modules/ROOT/pages/deployment.adoc
+++ b/docs/modules/ROOT/pages/deployment.adoc
@@ -53,10 +53,13 @@ NOTE: This deployment method does NOT use an `arion-pkgs.nix` file, but reuses
 
   virtualisation.arion = {
     backend = "podman-socket"; # or "docker"
-    projects.example.settings = {
-      # Specify you project here, or import it from a file.
-      # NOTE: This does NOT use ./arion-pkgs.nix, but defaults to NixOS' pkgs.
-      imports = [ ./arion-compose.nix ];
+    projects.example = {
+      serviceName = "example"; # optional systemd service name, defaults to arion-example in this case
+      settings = {
+        # Specify you project here, or import it from a file.
+        # NOTE: This does NOT use ./arion-pkgs.nix, but defaults to NixOS' pkgs.
+        imports = [ ./arion-compose.nix ];
+      };
     };
   };
 }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -26,9 +26,14 @@ let
         visible = "shallow";
       };
       _systemd = mkOption { internal = true; };
+      serviceName = mkOption {
+        description = "The name of the Arion project's systemd service";
+        type = types.str;
+        default = "arion-${name}";
+      };
     };
     config = {
-      _systemd.services."arion-${name}" = {
+      _systemd.services.${config.serviceName} = {
         wantedBy = [ "multi-user.target" ];
         after = [ "sockets.target" ];
 


### PR DESCRIPTION
Adds an option `serviceName` to the NixOS module so that users can override their systemd service names. This is functionality that I would like to have in my own personal use of Arion (I don't like having an inconsistent naming scheme for my services), and it was a pretty quick tweak, so I figured I'd submit a PR and see what happens. Also updated the docs to include the new option.