### PR TITLE
fix(flake): allow `defaultPackage` to evaluate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
 
         defaultPackage =
           lib.mapAttrs
-            (ps: lib.warn "arion.defaultPackage has been removed in favor of arion.packages.\${system}.default"
+            (_system: ps: lib.warn "arion.defaultPackage has been removed in favor of arion.packages.\${system}.default"
               ps.default)
             config.flake.packages;
 


### PR DESCRIPTION
by adding the missing (and in this case ignored) key/attribute-name argument to `lib.mapAttrs`.

Without this, trying to evaluate `defaultPackage` triggers the error `error: value is a string while a set was expected`.

Discovered in running `nix flake check` while working on #92.

Thanks!