### PR TITLE
rename boot.tmpOnTmpfs -> boot.tmp.useTmpfs

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -148,7 +148,7 @@ Describe containers using NixOS-style modules. There are a few options:
   project.name = "full-nixos";
   services.webserver = { pkgs, lib, ... }: {
     nixos.useSystemd = true;
-    nixos.configuration.boot.tmpOnTmpfs = true;
+    nixos.configuration.boot.tmp.useTmpfs = true;
     nixos.configuration.services.nginx.enable = true;
     nixos.configuration.services.nginx.virtualHosts.localhost.root = "${pkgs.nix.doc}/share/doc/nix/manual";
     nixos.configuration.services.nscd.enable = false;

--- a/examples/full-nixos/arion-compose.nix
+++ b/examples/full-nixos/arion-compose.nix
@@ -2,7 +2,7 @@
   project.name = "full-nixos";
   services.webserver = { pkgs, lib, ... }: {
     nixos.useSystemd = true;
-    nixos.configuration.boot.tmpOnTmpfs = true;
+    nixos.configuration.boot.tmp.useTmpfs = true;
     nixos.configuration.networking.useDHCP = false;
     nixos.configuration.services.nginx.enable = true;
     nixos.configuration.services.nginx.virtualHosts.localhost.root = "${pkgs.nix.doc}/share/doc/nix/manual";

--- a/src/haskell/testdata/Arion/NixSpec/arion-compose.nix
+++ b/src/haskell/testdata/Arion/NixSpec/arion-compose.nix
@@ -2,7 +2,7 @@
   project.name = "unit-test-data";
   services.webserver = { pkgs, ... }: {
     nixos.useSystemd = true;
-    nixos.configuration.boot.tmpOnTmpfs = true;
+    nixos.configuration.boot.tmp.useTmpfs = true;
     nixos.configuration.services.nginx.enable = true;
     nixos.configuration.services.nginx.virtualHosts.localhost.root = "${pkgs.nix.doc}/share/doc/nix/manual";
     service.useHostStore = true;


### PR DESCRIPTION
resolves warning:
> trace: Obsolete option `boot.tmpOnTmpfs' is used. It was renamed to `boot.tmp.useTmpfs'.

c.f.
https://github.com/NixOS/nixpkgs/commit/a5d95ac5fca37482f55feb0870c9ed6b1b9bb4b4