### PR TITLE
add support for docker compose secrets

### DIFF
--- a/arion-compose.cabal
+++ b/arion-compose.cabal
@@ -19,6 +19,7 @@ data-files:          nix/*.nix
                    , nix/modules/composition/*.nix
                    , nix/modules/networks/*.nix
                    , nix/modules/nixos/*.nix
+                   , nix/modules/secrets/*.nix
                    , nix/modules/service/*.nix
                    , nix/modules/lib/*.nix
 

--- a/src/haskell/testdata/Arion/NixSpec/arion-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-compose.json
@@ -4,6 +4,7 @@
             "name": "unit-test-data"
         }
     },
+    "secrets": {},
     "services": {
         "webserver": {
             "command": [

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
@@ -22,15 +22,15 @@
             "ports": [
                 "8080:80"
             ],
-            "secrets": {
-                "foo": {
-                    "gid": 123,
+            "secrets": [
+                {
+                    "gid": "123",
                     "mode": "0440",
-                    "source": "web_cache_redis_secret",
-                    "target": "/run/secrets/web_cache_redis_secret",
-                    "uid": 123
+                    "source": "foo",
+                    "target": "/run/secrets/foo",
+                    "uid": "123"
                 }
-            },
+            ],
             "sysctls": {},
             "volumes": []
         }

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
@@ -27,6 +27,7 @@
                     "gid": 123,
                     "mode": "0440",
                     "source": "web_cache_redis_secret",
+                    "target": "/run/secrets/web_cache_redis_secret",
                     "uid": 123
                 }
             },

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
@@ -21,6 +21,14 @@
             "ports": [
                 "8080:80"
             ],
+            "secrets": {
+                "foo": {
+                    "gid": 123,
+                    "mode": "0440",
+                    "source": "web_cache_redis_secret",
+                    "uid": 123
+                }
+            },
             "sysctls": {},
             "volumes": []
         }

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
@@ -6,7 +6,8 @@
     },
     "secrets": {
         "foo": {
-            "environment": "FOO"
+            "environment": "FOO",
+            "external": false
         }
     },
     "services": {

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
@@ -4,10 +4,18 @@
             "name": "unit-test-data"
         }
     },
+    "secrets": {
+        "foo": {
+            "environment": "FOO"
+        }
+    },
     "services": {
         "webserver": {
             "build": {
-                "context": "<STOREPATH>"
+                "context": "<STOREPATH>",
+                "secrets": [
+                    "foo"
+                ]
             },
             "environment": {},
             "ports": [

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
@@ -6,15 +6,15 @@
     ports = [
       "8080:80"
     ];
-    secrets = {
-      foo = {
-        source = "web_cache_redis_secret";
-        target = "/run/secrets/web_cache_redis_secret";
-        uid = 123;
-        gid = 123;
+    secrets = [
+      {
+        source = "foo";
+        target = "/run/secrets/foo";
+        uid = "123";
+        gid = "123";
         mode = "0440";
-      };
-    };
+      }
+    ];
   };
   secrets.foo.environment = "FOO";
 }

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
@@ -6,6 +6,14 @@
     ports = [
       "8080:80"
     ];
+    secrets = {
+      foo = {
+        source = "web_cache_redis_secret";
+        uid = 123;
+        gid = 123;
+        mode = "0440";
+      };
+    };
   };
   secrets.foo.environment = "FOO";
 }

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
@@ -9,6 +9,7 @@
     secrets = {
       foo = {
         source = "web_cache_redis_secret";
+        target = "/run/secrets/web_cache_redis_secret";
         uid = 123;
         gid = 123;
         mode = "0440";

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
@@ -6,15 +6,14 @@
     ports = [
       "8080:80"
     ];
-    secrets = [
-      {
-        source = "foo";
+    secrets = {
+      "foo" = {
         target = "/run/secrets/foo";
         uid = "123";
         gid = "123";
         mode = "0440";
-      }
-    ];
+      };
+    };
   };
   secrets.foo.environment = "FOO";
 }

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix
@@ -2,8 +2,10 @@
   project.name = "unit-test-data";
   services.webserver.service = {
     build.context = "${./build-context}";
+    build.secrets = ["foo"];
     ports = [
       "8080:80"
     ];
   };
+  secrets.foo.environment = "FOO";
 }

--- a/src/nix/lib.nix
+++ b/src/nix/lib.nix
@@ -11,11 +11,15 @@ let
   networkRef = fragment:
     ''See ${link "https://github.com/compose-spec/compose-spec/blob/${composeSpecRev}/06-networks.md#${fragment}" "Compose Spec Networks #${fragment}"}'';
 
+  secretRef = fragment:
+    ''See ${link "https://github.com/compose-spec/compose-spec/blob/${composeSpecRev}/09-secrets.md#${fragment}" "Compose Spec Secrets #${fragment}"}'';
+
 in
 {
   inherit
     link
     networkRef
     serviceRef
+    secretRef
     ;
 }

--- a/src/nix/modules.nix
+++ b/src/nix/modules.nix
@@ -3,6 +3,7 @@
     ./modules/composition/host-environment.nix
     ./modules/composition/images.nix
     ./modules/composition/networks.nix
+    ./modules/composition/secrets.nix
     ./modules/composition/service-info.nix
     ./modules/composition/composition.nix
 ]

--- a/src/nix/modules/composition/docker-compose.nix
+++ b/src/nix/modules/composition/docker-compose.nix
@@ -68,6 +68,14 @@ in
       description = "A attribute set of volume configurations.";
       default = {};
     };
+    docker-compose.secrets = lib.mkOption {
+      type = lib.types.attrsOf lib.types.unspecified;
+      description = ''
+        An attribute set of secret configurations. For more info, see:
+        https://docs.docker.com/compose/compose-file/09-secrets/
+      '';
+      default = {};
+    };
   };
   config = {
     out.dockerComposeYaml = pkgs.writeText "docker-compose.yaml" config.out.dockerComposeYamlText;
@@ -79,6 +87,7 @@ in
       services = lib.mapAttrs (k: c: c.out.service) config.services;
       x-arion = config.docker-compose.extended;
       volumes = config.docker-compose.volumes;
+      secrets = config.docker-compose.secrets;
     };
   };
 }

--- a/src/nix/modules/composition/secrets.nix
+++ b/src/nix/modules/composition/secrets.nix
@@ -1,0 +1,33 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkOption
+    types
+    ;
+  inherit (import ../../lib.nix { inherit lib; })
+    link
+    ;
+in
+{
+
+  options = {
+    secrets = mkOption {
+      type = types.lazyAttrsOf (types.submoduleWith {
+        modules = [
+          ../secrets/secret.nix
+        ];
+      });
+      description = ''
+        See ${link "https://docs.docker.com/compose/compose-file/09-secrets/" "Docker Compose Secrets"}
+      '';
+    };
+  };
+
+  config = {
+
+    secrets = {};
+    docker-compose.secrets = lib.mapAttrs (k: v: v.out) config.secrets;
+
+  };
+}

--- a/src/nix/modules/secrets/secret.nix
+++ b/src/nix/modules/secrets/secret.nix
@@ -28,6 +28,15 @@ in
       type = types.nullOr types.str;
     };
 
+    external = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether the value of this secret is set via other means.
+        ${secretRef "secrets"}
+      '';
+    };
+
     out = mkOption {
       internal = true;
       description = ''
@@ -48,6 +57,7 @@ in
             inherit (options)
               file
               environment
+              external
               ;
           }
         );

--- a/src/nix/modules/secrets/secret.nix
+++ b/src/nix/modules/secrets/secret.nix
@@ -17,7 +17,7 @@ in
         The secret is created with the contents of the file at the specified path.
         ${secretRef "file"}
       '';
-      type = types.nullOr types.str;
+      type = types.nullOr (types.either types.path types.str);
     };
 
     environment = mkOption {

--- a/src/nix/modules/secrets/secret.nix
+++ b/src/nix/modules/secrets/secret.nix
@@ -1,0 +1,55 @@
+{ config, lib, options, ... }:
+
+let
+  inherit (lib)
+    mkOption
+    optionalAttrs
+    types
+    ;
+  inherit (import ../../lib.nix { inherit lib; })
+    secretRef
+    ;
+in
+{
+  options = {
+    file = mkOption {
+      description = ''
+        The secret is created with the contents of the file at the specified path.
+        ${secretRef "file"}
+      '';
+      type = types.nullOr types.str;
+    };
+
+    environment = mkOption {
+      description = ''
+        The secret is created with the value of an environment variable.
+        ${secretRef "environment"}
+      '';
+      type = types.nullOr types.str;
+    };
+
+    out = mkOption {
+      internal = true;
+      description = ''
+        Defines sensitive data that is granted to the services in your Compose application.
+        The source of the secret is either `file` or `environment`.
+      '';
+      type = lib.types.attrsOf lib.types.raw or lib.types.unspecified;
+    };
+  };
+
+  config = {
+    out =
+      lib.mapAttrs
+        (k: opt: opt.value)
+        (lib.filterAttrs
+          (k: opt: opt.isDefined)
+          {
+            inherit (options)
+              file
+              environment
+              ;
+          }
+        );
+  };
+}

--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -25,6 +25,11 @@ let
         default = null;
         description = serviceRef "secrets";
       };
+      target = mkOption {
+        type = nullOr str;
+        default = null;
+        description = serviceRef "secrets";
+      };
       uid = mkOption {
         type = nullOr (either str int);
         default = null;
@@ -141,6 +146,7 @@ in
       example = {
         redis_secret = {
           source = "web_cache_redis_secret";
+          target = "/run/secrets/web_cache_redis_secret";
           uid = 123;
           gid = 123;
           mode = "0440";

--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -128,7 +128,7 @@ in
             '';
           };
           secrets = mkOption {
-            type = nullOr (listOf (either str serviceSecretType));
+            type = nullOr (either (listOf str) (attrsOf serviceSecretType));
             default = null;
             description = ''
               Build-time secrets exposed to the service.
@@ -138,7 +138,7 @@ in
       });
     };
     service.secrets = mkOption {
-      type = nullOr (listOf (either str serviceSecretType));
+      type = nullOr (either (listOf str) (attrsOf serviceSecretType));
       default = [];
       description = ''
         Run-time secrets exposed to the service.
@@ -451,7 +451,9 @@ in
   } // lib.optionalAttrs (config.service.extra_hosts != []) {
     inherit (config.service) extra_hosts;
   } // lib.optionalAttrs (config.service.secrets != []) {
-    secrets = lib.lists.map (s: {
+    secrets = lib.mapAttrsToList (k: s: {
+      source = k;
+      target = k;
     } // lib.optionalAttrs (s.source != null) {
       inherit (s) source;
     } // lib.optionalAttrs (s.target != null) {

--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -31,12 +31,12 @@ let
         description = serviceRef "secrets";
       };
       uid = mkOption {
-        type = nullOr (either str int);
+        type = nullOr str;
         default = null;
         description = serviceRef "secrets";
       };
       gid = mkOption {
-        type = nullOr (either str int);
+        type = nullOr str;
         default = null;
         description = serviceRef "secrets";
       };
@@ -128,7 +128,7 @@ in
             '';
           };
           secrets = mkOption {
-            type = nullOr (either (listOf str) (attrsOf serviceSecretType));
+            type = nullOr (listOf (either str serviceSecretType));
             default = null;
             description = ''
               Build-time secrets exposed to the service.
@@ -138,7 +138,7 @@ in
       });
     };
     service.secrets = mkOption {
-      type = either (listOf str) (attrsOf serviceSecretType);
+      type = nullOr (listOf (either str serviceSecretType));
       default = [];
       description = ''
         Run-time secrets exposed to the service.
@@ -451,7 +451,18 @@ in
   } // lib.optionalAttrs (config.service.extra_hosts != []) {
     inherit (config.service) extra_hosts;
   } // lib.optionalAttrs (config.service.secrets != []) {
-    inherit (config.service) secrets;
+    secrets = lib.lists.map (s: {
+    } // lib.optionalAttrs (s.source != null) {
+      inherit (s) source;
+    } // lib.optionalAttrs (s.target != null) {
+      inherit (s) target;
+    } // lib.optionalAttrs (s.uid != null) {
+      inherit (s) uid;
+    } // lib.optionalAttrs (s.gid != null) {
+      inherit (s) gid;
+    } // lib.optionalAttrs (s.mode != null) {
+      inherit (s) mode;
+    }) config.service.secrets;
   } // lib.optionalAttrs (config.service.hostname != null) {
     inherit (config.service) hostname;
   } // lib.optionalAttrs (config.service.dns != []) {

--- a/src/nix/modules/service/docker-compose-service.nix
+++ b/src/nix/modules/service/docker-compose-service.nix
@@ -57,29 +57,56 @@ in
       default = [];
       description = serviceRef "tmpfs";
     };
-    service.build.context = mkOption {
-      type = nullOr str;
-      default = null;
-      description = ''
-        Locates a Dockerfile to use for creating an image to use in this service.
+    service.build = mkOption {
+      default = {};
+      description = serviceRef "build";
+      type = submodule ({ options, ...}: {
+        options = {
+          _out = mkOption {
+            internal = true;
+            readOnly = true;
+            default = lib.mapAttrs (k: opt: opt.value) (lib.filterAttrs (_: opt: opt.value != null) { inherit (options) context dockerfile target secrets; });
+          };
+          context = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              Locates a Dockerfile to use for creating an image to use in this service.
 
-        https://docs.docker.com/compose/compose-file/build/#context
-      '';
+              https://docs.docker.com/compose/compose-file/build/#context
+            '';
+          };
+          dockerfile = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              Sets an alternate Dockerfile. A relative path is resolved from the build context.
+              https://docs.docker.com/compose/compose-file/build/#dockerfile
+            '';
+          };
+          target = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              Defines the stage to build as defined inside a multi-stage Dockerfile.
+              https://docs.docker.com/compose/compose-file/build/#target
+            '';
+          };
+          secrets = mkOption {
+            type = nullOr (listOf str);
+            default = null;
+            description = ''
+              Build-time secrets exposed to the service.
+            '';
+          };
+        };
+      });
     };
-    service.build.dockerfile = mkOption {
-      type = nullOr str;
-      default = null;
+    service.secrets = mkOption {
+      type = listOf str;
+      default = [];
       description = ''
-        Sets an alternate Dockerfile. A relative path is resolved from the build context.
-        https://docs.docker.com/compose/compose-file/build/#dockerfile
-      '';
-    };
-    service.build.target = mkOption {
-      type = nullOr str;
-      default = null;
-      description = ''
-        Defines the stage to build as defined inside a multi-stage Dockerfile.
-        https://docs.docker.com/compose/compose-file/build/#target
+        Run-time secrets exposed to the service.
       '';
     };
     service.hostname = mkOption {
@@ -353,8 +380,8 @@ in
       ;
   } // lib.optionalAttrs (config.service.image != null) {
     inherit (config.service) image;
-  } // lib.optionalAttrs (config.service.build.context != null ) {
-    build = lib.filterAttrs (n: v: v != null)  config.service.build;
+  } // lib.optionalAttrs (config.service.build._out != {}) {
+    build = config.service.build._out;
   } // lib.optionalAttrs (cap_add != []) {
     inherit cap_add;
   } // lib.optionalAttrs (cap_drop != []) {
@@ -379,6 +406,8 @@ in
     inherit (config.service) external_links;
   } // lib.optionalAttrs (config.service.extra_hosts != []) {
     inherit (config.service) extra_hosts;
+  } // lib.optionalAttrs (config.service.secrets != []) {
+    inherit (config.service) secrets;
   } // lib.optionalAttrs (config.service.hostname != null) {
     inherit (config.service) hostname;
   } // lib.optionalAttrs (config.service.dns != []) {


### PR DESCRIPTION
enables using [docker compose secrets](https://docs.docker.com/compose/use-secrets/) from arion, which includes:

- [top-level `secrets` element](https://docs.docker.com/compose/compose-file/09-secrets/) defining the secrets to be used
for the below two use-cases,
exposing them at `/run/secrets/<secret_name>`.
comes in flavors `file` vs `environment`.
- run-time: [`services` top-level `secrets` element](https://docs.docker.com/compose/compose-file/05-services/#secrets)
- build time: [build secrets](https://docs.docker.com/build/building/secrets/) (supported in docker compose tho not docker stack, to be [mounted](https://docs.docker.com/build/building/secrets/#secret-mounts) in the `Dockerfile` like
`RUN --mount=type=secret,id=<secret_name> ...`)

unlike #52, i did not so far add support for their [long syntax](https://docs.docker.com/compose/compose-file/05-services/#long-syntax-4), which despite the confusing documentation appears
[limited to Docker Swarm](https://github.com/docker/compose/issues/9648#issuecomment-1380290233), in my understanding currently limiting its use  in Arion.
