### PR TITLE
 DRAFT: add deploy sub-command invoking docker stack deploy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
           devShells.default = config.devShells.haskell-package.overrideAttrs (o: {
             nativeBuildInputs = o.nativeBuildInputs or [ ] ++ [
               pkgs.docker-compose
+              pkgs.docker
               pkgs.nixpkgs-fmt
               config.haskellProjects.haskell-package.haskellPackages.releaser
             ];

--- a/nix/upstreamable/default.nix
+++ b/nix/upstreamable/default.nix
@@ -57,7 +57,7 @@ let
       mv $out/bin/arion $out/libexec
       makeWrapper $out/libexec/arion $out/bin/arion \
         --unset PYTHONPATH \
-        --prefix PATH : ${lib.makeBinPath [ pkgs.docker-compose ]} \
+        --prefix PATH : ${lib.makeBinPath [ pkgs.docker-compose pkgs.docker ]} \
         ;
     '';
   };

--- a/src/haskell/exe/Main.hs
+++ b/src/haskell/exe/Main.hs
@@ -112,6 +112,7 @@ parseCommand =
       <> commandDC runEvalAndDC "top" "Display the running processes"
       <> commandDC runEvalAndDC "unpause" "Unpause services"
       <> commandDC runBuildAndDC "up" "Create and start containers"
+      <> commandDC runEvalAndDC "deploy" "Deploy a new stack or update an existing stack"
       <> commandDC runDC "version" "Show the Docker-Compose version information"
 
       <> metavar "DOCKER-COMPOSE-COMMAND"
@@ -164,7 +165,10 @@ callDC cmd dopts opts shouldLoadImages path = do
   let firstOpts = projectArgs extendedInfo <> commonArgs opts
   DockerCompose.run DockerCompose.Args
     { files = [path]
-    , otherArgs = firstOpts ++ [cmd] ++ unDockerComposeArgs dopts
+    , otherArgs = case cmd of
+        "deploy" -> unDockerComposeArgs dopts ++ toList (projectName extendedInfo)
+        _ -> firstOpts ++ [cmd] ++ unDockerComposeArgs dopts
+    , useSwarm = cmd == "deploy"
     }
 
 projectArgs :: ExtendedInfo -> [Text]
@@ -314,6 +318,7 @@ runExec detach privileged user noTTY index envs workDir service commandAndArgs o
     DockerCompose.run DockerCompose.Args
       { files = [path]
       , otherArgs = projectArgs extendedInfo <> commonArgs opts <> args
+      , useSwarm = False
       }
 
 main :: IO ()

--- a/src/haskell/lib/Arion/DockerCompose.hs
+++ b/src/haskell/lib/Arion/DockerCompose.hs
@@ -8,14 +8,20 @@ import           System.Process
 data Args = Args
   { files :: [FilePath]
   , otherArgs :: [Text]
+  , useSwarm :: Bool
   }
 
 run :: Args -> IO ()
 run args = do
-  let fileArgs = files args >>= \f -> ["--file", f]
-      allArgs  = fileArgs ++ map toS (otherArgs args)
+  let (executable, fileParam) = case useSwarm args of
+        False -> ("docker-compose", "--file")
+        True -> ("docker", "--compose-file")
+      fileArgs = files args >>= \f -> [fileParam, f]
+      allArgs = case useSwarm args of
+            False -> fileArgs ++ map toS (otherArgs args)
+            True -> ["stack", "deploy"] ++ fileArgs ++ map toS (otherArgs args)
 
-      procSpec = proc "docker-compose" allArgs
+      procSpec = proc executable allArgs
 
   -- hPutStrLn stderr ("Running docker-compose with " <> show allArgs :: Text)
 

--- a/src/haskell/testdata/Arion/NixSpec/arion-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-compose.json
@@ -32,7 +32,7 @@
             ]
         }
     },
-    "version": "3.4",
+    "version": "3.8",
     "volumes": {},
     "x-arion": {
         "images": [

--- a/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
+++ b/src/haskell/testdata/Arion/NixSpec/arion-context-compose.json
@@ -17,7 +17,7 @@
             "volumes": []
         }
     },
-    "version": "3.4",
+    "version": "3.8",
     "volumes": {},
     "x-arion": {
         "images": [

--- a/src/haskell/testdata/docker-compose-example.json
+++ b/src/haskell/testdata/docker-compose-example.json
@@ -21,7 +21,7 @@
       ]
     }
   },
-  "version": "3.4",
+  "version": "3.8",
   "x-arion": {
     "images": [
       {

--- a/src/nix/modules/composition/docker-compose.nix
+++ b/src/nix/modules/composition/docker-compose.nix
@@ -75,7 +75,7 @@ in
     out.dockerComposeYamlAttrs = config.assertWarn config.docker-compose.raw;
 
     docker-compose.raw = {
-      version = "3.4";
+      version = "3.8";
       services = lib.mapAttrs (k: c: c.out.service) config.services;
       x-arion = config.docker-compose.extended;
       volumes = config.docker-compose.volumes;


### PR DESCRIPTION
as per my curiosity toward docker stack/swarm stemming from their [support for external / long-syntax secrets](https://github.com/hercules-ci/arion/pull/255#issuecomment-2266649692), i tried my hand at a quick implementation adding a `deploy` sub-command invoking [`docker stack deploy`](https://docs.docker.com/reference/cli/docker/stack/deploy/).
my implementation here is kinda hacky, so this may need some more eyes.

that said, `stack deploy` seems the primary command in docker stack/swarm involving the compose file arion manages thru nix, so one could as well just invoke their remaining commands directly.
