### PR TITLE
Maintenance

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,2 @@
-HOST_XDG_DATA_DIRS="${XDG_DATA_DIRS:-}"
-eval "$(lorri direnv)"
-export XDG_DATA_DIRS="${XDG_DATA_DIRS}:${HOST_XDG_DATA_DIRS}"
+use flake
 
-# Use system PKI
-unset SSL_CERT_FILE
-unset NIX_SSL_CERT_FILE

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/arion-compose.cabal
+++ b/arion-compose.cabal
@@ -44,6 +44,15 @@ common common
                    , protolude >= 0.2
                    , unix
   ghc-options:     -Wall
+  default-extensions:
+    BlockArguments
+    DeriveAnyClass
+    DeriveGeneric
+    DerivingStrategies
+    LambdaCase
+    NoFieldSelectors
+    OverloadedRecordDot
+    OverloadedStrings
 
 flag ghci
   default: False

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -28,9 +28,9 @@
   };
 
   herculesCI.ciSystems = [
-    # "aarch64-darwin"
+    "aarch64-darwin"
     # "aarch64-linux"
-    "x86_64-darwin"
+    # "x86_64-darwin"
     "x86_64-linux"
   ];
 

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -1,0 +1,28 @@
+{
+  perSystem = { config, self', inputs', pkgs, system, final, ... }: {
+    devShells.default = config.devShells.haskell-package.overrideAttrs (o: {
+      nativeBuildInputs = o.nativeBuildInputs or [ ] ++ [
+        pkgs.docker-compose
+        pkgs.nixpkgs-fmt
+        config.haskellProjects.haskell-package.haskellPackages.releaser
+      ];
+    });
+  };
+
+  hercules-ci.flake-update = {
+    enable = true;
+    autoMergeMethod = "merge";
+    when = {
+      hour = [ 2 ];
+      dayOfMonth = [ 5 ];
+    };
+  };
+
+  herculesCI.ciSystems = [
+    # "aarch64-darwin"
+    # "aarch64-linux"
+    "x86_64-darwin"
+    "x86_64-linux"
+  ];
+
+}

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -12,6 +12,10 @@
   hercules-ci.flake-update = {
     enable = true;
     autoMergeMethod = "merge";
+    flakes = {
+      "." = { };
+      "dev" = { };
+    };
     when = {
       hour = [ 2 ];
       dayOfMonth = [ 5 ];

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -1,11 +1,16 @@
 {
   perSystem = { config, self', inputs', pkgs, system, final, ... }: {
+    pre-commit.settings.hooks.ormolu.enable = true;
     devShells.default = config.devShells.haskell-package.overrideAttrs (o: {
       nativeBuildInputs = o.nativeBuildInputs or [ ] ++ [
         pkgs.docker-compose
         pkgs.nixpkgs-fmt
         config.haskellProjects.haskell-package.haskellPackages.releaser
       ];
+      shellHook = ''
+        ${config.pre-commit.installationScript}
+        echo 1>&2 "Welcome to the arion dev shell"
+      '';
     });
   };
 

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -20,10 +36,52 @@
         "type": "indirect"
       }
     },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1733665616,
+        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "hercules-ci-effects": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1733333617,
@@ -41,6 +99,38 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1733212471,
         "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
         "owner": "NixOS",
@@ -57,6 +147,7 @@
     },
     "root": {
       "inputs": {
+        "git-hooks-nix": "git-hooks-nix",
         "hercules-ci-effects": "hercules-ci-effects"
       }
     }

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -3,6 +3,7 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "hercules-ci-effects",
           "nixpkgs"
         ]
       },
@@ -15,24 +16,26 @@
         "type": "github"
       },
       "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
-    "haskell-flake": {
+    "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1675296942,
-        "narHash": "sha256-u1X1sblozi5qYEcLp1hxcyo8FfDHnRUVX3dJ/tW19jY=",
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "rev": "c2cafce9d57bfca41794dc3b99c593155006c71e",
+        "lastModified": 1733333617,
+        "narHash": "sha256-nMMQXREGvLOLvUa0ByhYFdaL0Jov0t1wzLbKjr05P2w=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "56f8ea8d502c87cf62444bec4ee04512e8ea24ea",
         "type": "github"
       },
       "original": {
-        "owner": "srid",
-        "ref": "0.1.0",
-        "repo": "haskell-flake",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
         "type": "github"
       }
     },
@@ -54,9 +57,7 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
-        "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs"
+        "hercules-ci-effects": "hercules-ci-effects"
       }
     }
   },

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -1,0 +1,8 @@
+{
+  # TODO move back into main lock after https://github.com/NixOS/nix/issues/7730, remove this subflake
+  description = "Development dependencies in a separate subflake so that they don't end up in your lock";
+  inputs = {
+    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+  };
+  outputs = { ... }: { };
+}

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -3,6 +3,7 @@
   description = "Development dependencies in a separate subflake so that they don't end up in your lock";
   inputs = {
     hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+    git-hooks-nix.url = "github:cachix/git-hooks.nix";
   };
   outputs = { ... }: { };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         module = { inputs, ... }: {
           imports = [
             inputs.hercules-ci-effects.flakeModule
+            inputs.git-hooks-nix.flakeModule
             ./tests/flake-module.nix
             ./dev/flake-module.nix
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -6,8 +6,6 @@
     haskell-flake.url = "github:srid/haskell-flake/0.1.0";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
-    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
-    hercules-ci-effects.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = inputs@{ self, flake-parts, ... }:
@@ -20,7 +18,8 @@
       ];
 
       partitions.dev = {
-        module = {
+        extraInputsFlake = ./dev;
+        module = { inputs, ... }: {
           imports = [
             inputs.hercules-ci-effects.flakeModule
             ./tests/flake-module.nix

--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,24 @@
     flake-parts.lib.mkFlake { inherit inputs; } ({ config, lib, extendModules, ... }: {
       imports = [
         inputs.haskell-flake.flakeModule
-        inputs.hercules-ci-effects.flakeModule
         inputs.flake-parts.flakeModules.easyOverlay
+        inputs.flake-parts.flakeModules.partitions
         ./docs/flake-module.nix
-        ./tests/flake-module.nix
       ];
+
+      partitions.dev = {
+        module = {
+          imports = [
+            inputs.hercules-ci-effects.flakeModule
+            ./tests/flake-module.nix
+            ./dev/flake-module.nix
+          ];
+        };
+      };
+      partitionedAttrs.devShells = "dev";
+      partitionedAttrs.checks = "dev";
+      partitionedAttrs.herculesCI = "dev";
+
       systems = inputs.nixpkgs.lib.systems.flakeExposed;
       perSystem = { config, self', inputs', pkgs, system, final, ... }:
         let h = pkgs.haskell.lib.compose; in
@@ -58,30 +71,7 @@
                   ];
               };
           };
-          devShells.default = config.devShells.haskell-package.overrideAttrs (o: {
-            nativeBuildInputs = o.nativeBuildInputs or [ ] ++ [
-              pkgs.docker-compose
-              pkgs.nixpkgs-fmt
-              config.haskellProjects.haskell-package.haskellPackages.releaser
-            ];
-          });
         };
-
-      hercules-ci.flake-update = {
-        enable = true;
-        autoMergeMethod = "merge";
-        when = {
-          hour = [ 2 ];
-          dayOfMonth = [ 5 ];
-        };
-      };
-
-      herculesCI.ciSystems = [
-        # "aarch64-darwin"
-        # "aarch64-linux"
-        "x86_64-darwin"
-        "x86_64-linux"
-      ];
 
       flake = {
         debug = { inherit inputs config lib; };

--- a/src/haskell/exe/Main.hs
+++ b/src/haskell/exe/Main.hs
@@ -211,12 +211,12 @@ defaultEvaluationArgs :: CommonOptions -> IO EvaluationArgs
 defaultEvaluationArgs co = do
   uid <- getRealUserID
   pure EvaluationArgs
-    { evalUid = fromIntegral uid
-    , evalModules = co.files
-    , evalPkgs = co.pkgs
-    , evalWorkDir = Nothing
-    , evalMode = ReadWrite
-    , evalUserArgs = co.nixArgs
+    { posixUID = fromIntegral uid
+    , evalModulesFile = co.files
+    , pkgsExpr = co.pkgs
+    , workDir = Nothing
+    , mode = ReadWrite
+    , extraNixArgs = co.nixArgs
     }
 
 runCat :: CommonOptions -> IO ()

--- a/src/haskell/lib/Arion/Aeson.hs
+++ b/src/haskell/lib/Arion/Aeson.hs
@@ -1,25 +1,27 @@
 module Arion.Aeson where
 
-import Prelude ()
-import           Data.Aeson
-import qualified Data.ByteString.Lazy          as BL
-import qualified Data.Text.Lazy                as TL
-import qualified Data.Text.Lazy.Builder        as TB
+import Data.Aeson
+import Data.Aeson.Encode.Pretty
+  ( confCompare,
+    confTrailingNewline,
+    defConfig,
+  )
 import qualified Data.Aeson.Encode.Pretty
-import           Data.Aeson.Encode.Pretty       ( defConfig
-                                                , confCompare
-                                                , confTrailingNewline
-                                                )
-import           Protolude
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TB
+import Protolude
+import Prelude ()
 
-pretty :: ToJSON a => a -> Text
+pretty :: (ToJSON a) => a -> Text
 pretty =
   TL.toStrict
     . TB.toLazyText
     . Data.Aeson.Encode.Pretty.encodePrettyToTextBuilder' config
-  where config = defConfig { confCompare = compare, confTrailingNewline = True }
+  where
+    config = defConfig {confCompare = compare, confTrailingNewline = True}
 
-decodeFile :: FromJSON a => FilePath -> IO a
+decodeFile :: (FromJSON a) => FilePath -> IO a
 decodeFile fp = do
   b <- BL.readFile fp
   case eitherDecode b of

--- a/src/haskell/lib/Arion/DockerCompose.hs
+++ b/src/haskell/lib/Arion/DockerCompose.hs
@@ -1,25 +1,24 @@
 module Arion.DockerCompose where
 
-import           Prelude                        ( )
-import           Protolude
-import           System.Process
+import Protolude
+import System.Process
+import Prelude ()
 
 data Args = Args
-  { files :: [FilePath]
-  , otherArgs :: [Text]
+  { files :: [FilePath],
+    otherArgs :: [Text]
   }
 
 run :: Args -> IO ()
 run args = do
   let fileArgs = args.files >>= \f -> ["--file", f]
-      allArgs  = fileArgs ++ map toS args.otherArgs
+      allArgs = fileArgs ++ map toS args.otherArgs
 
       procSpec = proc "docker-compose" allArgs
 
   -- hPutStrLn stderr ("Running docker-compose with " <> show allArgs :: Text)
 
   withCreateProcess procSpec $ \_in _out _err procHandle -> do
-
     exitCode <- waitForProcess procHandle
 
     case exitCode of

--- a/src/haskell/lib/Arion/DockerCompose.hs
+++ b/src/haskell/lib/Arion/DockerCompose.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Arion.DockerCompose where
 
 import           Prelude                        ( )
@@ -12,8 +11,8 @@ data Args = Args
 
 run :: Args -> IO ()
 run args = do
-  let fileArgs = files args >>= \f -> ["--file", f]
-      allArgs  = fileArgs ++ map toS (otherArgs args)
+  let fileArgs = args.files >>= \f -> ["--file", f]
+      allArgs  = fileArgs ++ map toS args.otherArgs
 
       procSpec = proc "docker-compose" allArgs
 

--- a/src/haskell/lib/Arion/ExtendedInfo.hs
+++ b/src/haskell/lib/Arion/ExtendedInfo.hs
@@ -5,31 +5,36 @@ Parses the x-arion field in the generated compose file.
 -}
 module Arion.ExtendedInfo where
 
-import Prelude()
-import Protolude
-import Data.Aeson as Aeson
 import Arion.Aeson
 import Control.Lens
+import Data.Aeson as Aeson
 import Data.Aeson.Lens
+import Protolude
+import Prelude ()
 
 data Image = Image
-  { image :: Maybe Text -- ^ image tar.gz file path
-  , imageExe :: Maybe Text -- ^ path to exe producing image tar
-  , imageName :: Text
-  , imageTag :: Text
-  } deriving stock (Eq, Show, Generic)
-    deriving anyclass (Aeson.ToJSON, Aeson.FromJSON)
+  { -- | image tar.gz file path
+    image :: Maybe Text,
+    -- | path to exe producing image tar
+    imageExe :: Maybe Text,
+    imageName :: Text,
+    imageTag :: Text
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (Aeson.ToJSON, Aeson.FromJSON)
 
-data ExtendedInfo = ExtendedInfo {
-    projectName :: Maybe Text,
+data ExtendedInfo = ExtendedInfo
+  { projectName :: Maybe Text,
     images :: [Image]
-  } deriving stock (Eq, Show)
+  }
+  deriving stock (Eq, Show)
 
 loadExtendedInfoFromPath :: FilePath -> IO ExtendedInfo
 loadExtendedInfoFromPath fp = do
   v <- decodeFile fp
-  pure ExtendedInfo {
-    -- TODO: use aeson derived instance?
-    projectName = v ^? key "x-arion" . key "project" . key "name" . _String,
-    images = (v :: Aeson.Value) ^.. key "x-arion" . key "images" . _Array . traverse . _JSON
-  }
+  pure
+    ExtendedInfo
+      { -- TODO: use aeson derived instance?
+        projectName = v ^? key "x-arion" . key "project" . key "name" . _String,
+        images = (v :: Aeson.Value) ^.. key "x-arion" . key "images" . _Array . traverse . _JSON
+      }

--- a/src/haskell/lib/Arion/ExtendedInfo.hs
+++ b/src/haskell/lib/Arion/ExtendedInfo.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-
 
 Parses the x-arion field in the generated compose file.
@@ -20,12 +17,13 @@ data Image = Image
   , imageExe :: Maybe Text -- ^ path to exe producing image tar
   , imageName :: Text
   , imageTag :: Text
-  } deriving (Eq, Show, Generic, Aeson.ToJSON, Aeson.FromJSON)
+  } deriving stock (Eq, Show, Generic)
+    deriving anyclass (Aeson.ToJSON, Aeson.FromJSON)
 
 data ExtendedInfo = ExtendedInfo {
     projectName :: Maybe Text,
     images :: [Image]
-  } deriving (Eq, Show)
+  } deriving stock (Eq, Show)
 
 loadExtendedInfoFromPath :: FilePath -> IO ExtendedInfo
 loadExtendedInfoFromPath fp = do

--- a/src/haskell/lib/Arion/Images.hs
+++ b/src/haskell/lib/Arion/Images.hs
@@ -1,52 +1,49 @@
 module Arion.Images
-  ( loadImages
-  ) where
+  ( loadImages,
+  )
+where
 
-import Prelude()
-import Protolude hiding (to)
-
-import qualified System.Process as Process
+import Arion.ExtendedInfo (Image (..))
 import qualified Data.Text as T
-
-import Arion.ExtendedInfo (Image(..))
+import Protolude hiding (to)
+import qualified System.Process as Process
+import Prelude ()
 
 type TaggedImage = Text
 
 -- | Subject to change
 loadImages :: [Image] -> IO ()
 loadImages requestedImages = do
-
   loaded <- getDockerImages
 
-  let
-    isNew :: Image -> Bool
-    isNew i =
-      -- On docker, the image name is unmodified
-      (i.imageName <> ":" <> i.imageTag) `notElem` loaded
-      -- On podman, you used to automatically get a localhost prefix
-      -- however, since NixOS 22.05, this expected to be part of the name instead
-        && ("localhost/" <> i.imageName <> ":" <> i.imageTag) `notElem` loaded
+  let isNew :: Image -> Bool
+      isNew i =
+        -- On docker, the image name is unmodified
+        (i.imageName <> ":" <> i.imageTag) `notElem` loaded
+          -- On podman, you used to automatically get a localhost prefix
+          -- however, since NixOS 22.05, this expected to be part of the name instead
+          && ("localhost/" <> i.imageName <> ":" <> i.imageTag) `notElem` loaded
 
   traverse_ loadImage . filter isNew $ requestedImages
 
 loadImage :: Image -> IO ()
-loadImage Image { image = Just imgPath, imageName = name } =
+loadImage Image {image = Just imgPath, imageName = name} =
   withFile (toS imgPath) ReadMode $ \fileHandle -> do
-  let procSpec = (Process.proc "docker" [ "load" ]) {
-          Process.std_in = Process.UseHandle fileHandle
-        }
-  Process.withCreateProcess procSpec $ \_in _out _err procHandle -> do
-    e <- Process.waitForProcess procHandle
-    case e of
-      ExitSuccess -> pass
-      ExitFailure code ->
-        panic $ "docker load failed with exit code " <> show code <> " for image " <> name <> " from path " <> imgPath
-
-loadImage Image { imageExe = Just imgExe, imageName = name } = do
-  let loadSpec = (Process.proc "docker" [ "load" ]) { Process.std_in = Process.CreatePipe }
+    let procSpec =
+          (Process.proc "docker" ["load"])
+            { Process.std_in = Process.UseHandle fileHandle
+            }
+    Process.withCreateProcess procSpec $ \_in _out _err procHandle -> do
+      e <- Process.waitForProcess procHandle
+      case e of
+        ExitSuccess -> pass
+        ExitFailure code ->
+          panic $ "docker load failed with exit code " <> show code <> " for image " <> name <> " from path " <> imgPath
+loadImage Image {imageExe = Just imgExe, imageName = name} = do
+  let loadSpec = (Process.proc "docker" ["load"]) {Process.std_in = Process.CreatePipe}
   Process.withCreateProcess loadSpec $ \(Just inHandle) _out _err loadProcHandle -> do
     let streamSpec = Process.proc (toS imgExe) []
-    Process.withCreateProcess streamSpec { Process.std_out = Process.UseHandle inHandle } $ \_ _ _ streamProcHandle ->
+    Process.withCreateProcess streamSpec {Process.std_out = Process.UseHandle inHandle} $ \_ _ _ streamProcHandle ->
       withAsync (Process.waitForProcess loadProcHandle) $ \loadExitAsync ->
         withAsync (Process.waitForProcess streamProcHandle) $ \streamExitAsync -> do
           r <- waitEither loadExitAsync streamExitAsync
@@ -59,12 +56,10 @@ loadImage Image { imageExe = Just imgExe, imageName = name } = do
             ExitFailure code -> panic $ "docker load failed with exit code " <> show code <> " for image " <> name <> " produced by executable " <> imgExe
             _ -> pass
           pass
-
-loadImage Image { imageName = name } = do
+loadImage Image {imageName = name} = do
   panic $ "image " <> name <> " doesn't specify an image file or imageExe executable"
-
 
 getDockerImages :: IO [TaggedImage]
 getDockerImages = do
-  let procSpec = Process.proc "docker" [ "images",  "--filter", "dangling=false", "--format", "{{.Repository}}:{{.Tag}}" ]
+  let procSpec = Process.proc "docker" ["images", "--filter", "dangling=false", "--format", "{{.Repository}}:{{.Tag}}"]
   map toS . T.lines . toS <$> Process.readCreateProcess procSpec ""

--- a/src/haskell/lib/Arion/Images.hs
+++ b/src/haskell/lib/Arion/Images.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE OverloadedStrings #-}
 module Arion.Images
   ( loadImages
   ) where
@@ -22,12 +19,13 @@ loadImages requestedImages = do
   loaded <- getDockerImages
 
   let
+    isNew :: Image -> Bool
     isNew i =
       -- On docker, the image name is unmodified
-      (imageName i <> ":" <> imageTag i) `notElem` loaded
+      (i.imageName <> ":" <> i.imageTag) `notElem` loaded
       -- On podman, you used to automatically get a localhost prefix
       -- however, since NixOS 22.05, this expected to be part of the name instead
-        && ("localhost/" <> imageName i <> ":" <> imageTag i) `notElem` loaded
+        && ("localhost/" <> i.imageName <> ":" <> i.imageTag) `notElem` loaded
 
   traverse_ loadImage . filter isNew $ requestedImages
 

--- a/src/haskell/lib/Arion/Nix.hs
+++ b/src/haskell/lib/Arion/Nix.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Arion.Nix
   ( evaluateComposition
   , withEvaluatedComposition
@@ -52,11 +51,11 @@ evaluateComposition ea = do
       args =
         [ evalComposition ]
         ++ commandArgs
-        ++ modeArguments (evalMode ea)
+        ++ modeArguments ea.evalMode
         ++ argArgs ea
-        ++ map toS (evalUserArgs ea)
+        ++ map toS ea.evalUserArgs
       procSpec = (proc "nix-instantiate" args)
-        { cwd = evalWorkDir ea
+        { cwd = ea.evalWorkDir
         , std_out = CreatePipe
         }
   
@@ -102,8 +101,8 @@ buildComposition outLink ea = do
         [ evalComposition ]
         ++ commandArgs
         ++ argArgs ea
-        ++ map toS (evalUserArgs ea)
-      procSpec = (proc "nix-build" args) { cwd = evalWorkDir ea }
+        ++ map toS ea.evalUserArgs
+      procSpec = (proc "nix-build" args) { cwd = ea.evalWorkDir }
   
   withCreateProcess procSpec $ \_in _out _err procHandle -> do
 
@@ -133,8 +132,8 @@ replForComposition ea = do
     let args =
           [ "repl", "--file", evalComposition ]
           ++ argArgs ea
-          ++ map toS (evalUserArgs ea)
-        procSpec = (proc "nix" args) { cwd = evalWorkDir ea }
+          ++ map toS ea.evalUserArgs
+        procSpec = (proc "nix" args) { cwd = ea.evalWorkDir }
     
     withCreateProcess procSpec $ \_in _out _err procHandle -> do
 
@@ -150,13 +149,13 @@ argArgs :: EvaluationArgs -> [[Char]]
 argArgs ea =
       [ "--argstr"
       , "uid"
-      , show $ evalUid ea
+      , show ea.evalUid
       , "--arg"
       , "modules"
-      , modulesNixExpr $ evalModules ea
+      , modulesNixExpr ea.evalModules
       , "--arg"
       , "pkgs"
-      , toS $ evalPkgs ea
+      , toS ea.evalPkgs
       ]
 
 getEvalCompositionFile :: IO FilePath

--- a/src/haskell/lib/Arion/Nix.hs
+++ b/src/haskell/lib/Arion/Nix.hs
@@ -1,64 +1,64 @@
 module Arion.Nix
-  ( evaluateComposition
-  , withEvaluatedComposition
-  , buildComposition
-  , withBuiltComposition
-  , replForComposition
-  , EvaluationArgs(..)
-  , EvaluationMode(..)
-  ) where
+  ( evaluateComposition,
+    withEvaluatedComposition,
+    buildComposition,
+    withBuiltComposition,
+    replForComposition,
+    EvaluationArgs (..),
+    EvaluationMode (..),
+  )
+where
 
-import           Prelude                        ( )
-import           Protolude
-import           Arion.Aeson                    ( pretty )
-import           Data.Aeson
+import Arion.Aeson (pretty)
+import Control.Arrow ((>>>))
+import Data.Aeson
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.List.NonEmpty as NE
 import qualified Data.String
-import qualified System.Directory              as Directory
-import           System.Process
-import qualified Data.ByteString.Lazy          as BL
-import           Paths_arion_compose
+import qualified Data.Text.IO as T
+import Paths_arion_compose
+import Protolude
+import qualified System.Directory as Directory
+import System.IO (hClose)
+import System.IO.Temp (withTempFile)
+import System.Process
+import Prelude ()
 
-import qualified Data.Text.IO                  as T
-
-import qualified Data.List.NonEmpty            as NE
-
-import           Control.Arrow                  ( (>>>) )
-import           System.IO.Temp                 ( withTempFile )
-import           System.IO                      ( hClose )
-
-data EvaluationMode =
-  ReadWrite | ReadOnly
+data EvaluationMode
+  = ReadWrite
+  | ReadOnly
 
 data EvaluationArgs = EvaluationArgs
- { posixUID :: Int
- , evalModulesFile :: NonEmpty FilePath
- , pkgsExpr :: Text
- , workDir :: Maybe FilePath
- , mode :: EvaluationMode
- , extraNixArgs :: [Text]
- }
+  { posixUID :: Int,
+    evalModulesFile :: NonEmpty FilePath,
+    pkgsExpr :: Text,
+    workDir :: Maybe FilePath,
+    mode :: EvaluationMode,
+    extraNixArgs :: [Text]
+  }
 
 evaluateComposition :: EvaluationArgs -> IO Value
 evaluateComposition ea = do
   evalComposition <- getEvalCompositionFile
   let commandArgs =
-        [ "--eval"
-        , "--strict"
-        , "--json"
-        , "--attr"
-        , "config.out.dockerComposeYamlAttrs"
+        [ "--eval",
+          "--strict",
+          "--json",
+          "--attr",
+          "config.out.dockerComposeYamlAttrs"
         ]
       args =
-        [ evalComposition ]
-        ++ commandArgs
-        ++ modeArguments ea.mode
-        ++ argArgs ea
-        ++ map toS ea.extraNixArgs
-      procSpec = (proc "nix-instantiate" args)
-        { cwd = ea.workDir
-        , std_out = CreatePipe
-        }
-  
+        [evalComposition]
+          ++ commandArgs
+          ++ modeArguments ea.mode
+          ++ argArgs ea
+          ++ map toS ea.extraNixArgs
+      procSpec =
+        (proc "nix-instantiate" args)
+          { cwd = ea.workDir,
+            std_out = CreatePipe
+          }
+
   withCreateProcess procSpec $ \_in outHM _err procHandle -> do
     let outHandle = fromMaybe (panic "stdout missing") outHM
 
@@ -76,7 +76,7 @@ evaluateComposition ea = do
 
     case v of
       Right r -> pure r
-      Left  e -> throwIO $ FatalError ("Couldn't parse nix-instantiate output" <> show e)
+      Left e -> throwIO $ FatalError ("Couldn't parse nix-instantiate output" <> show e)
 
 -- | Run with docker-compose.yaml tmpfile
 withEvaluatedComposition :: EvaluationArgs -> (FilePath -> IO r) -> IO r
@@ -87,25 +87,23 @@ withEvaluatedComposition ea f = do
     hClose yamlHandle
     f path
 
-
 buildComposition :: FilePath -> EvaluationArgs -> IO ()
 buildComposition outLink ea = do
   evalComposition <- getEvalCompositionFile
   let commandArgs =
-        [ "--attr"
-        , "config.out.dockerComposeYaml"
-        , "--out-link"
-        , outLink
+        [ "--attr",
+          "config.out.dockerComposeYaml",
+          "--out-link",
+          outLink
         ]
       args =
-        [ evalComposition ]
-        ++ commandArgs
-        ++ argArgs ea
-        ++ map toS ea.extraNixArgs
-      procSpec = (proc "nix-build" args) { cwd = ea.workDir }
-  
-  withCreateProcess procSpec $ \_in _out _err procHandle -> do
+        [evalComposition]
+          ++ commandArgs
+          ++ argArgs ea
+          ++ map toS ea.extraNixArgs
+      procSpec = (proc "nix-build" args) {cwd = ea.workDir}
 
+  withCreateProcess procSpec $ \_in _out _err procHandle -> do
     exitCode <- waitForProcess procHandle
 
     case exitCode of
@@ -125,58 +123,57 @@ withBuiltComposition ea f = do
     buildComposition path ea
     f path
 
-
 replForComposition :: EvaluationArgs -> IO ()
 replForComposition ea = do
-    evalComposition <- getEvalCompositionFile
-    let args =
-          [ "repl", "--file", evalComposition ]
+  evalComposition <- getEvalCompositionFile
+  let args =
+        ["repl", "--file", evalComposition]
           ++ argArgs ea
           ++ map toS ea.extraNixArgs
-        procSpec = (proc "nix" args) { cwd = ea.workDir }
-    
-    withCreateProcess procSpec $ \_in _out _err procHandle -> do
+      procSpec = (proc "nix" args) {cwd = ea.workDir}
 
-      exitCode <- waitForProcess procHandle
+  withCreateProcess procSpec $ \_in _out _err procHandle -> do
+    exitCode <- waitForProcess procHandle
 
-      case exitCode of
-        ExitSuccess -> pass
-        ExitFailure 1 -> exitFailure
-        ExitFailure {} -> do
-          throwIO $ FatalError $ "nix repl failed with " <> show exitCode
+    case exitCode of
+      ExitSuccess -> pass
+      ExitFailure 1 -> exitFailure
+      ExitFailure {} -> do
+        throwIO $ FatalError $ "nix repl failed with " <> show exitCode
 
 argArgs :: EvaluationArgs -> [[Char]]
 argArgs ea =
-      [ "--argstr"
-      , "uid"
-      , show ea.posixUID
-      , "--arg"
-      , "modules"
-      , modulesNixExpr ea.evalModulesFile
-      , "--arg"
-      , "pkgs"
-      , toS ea.pkgsExpr
-      ]
+  [ "--argstr",
+    "uid",
+    show ea.posixUID,
+    "--arg",
+    "modules",
+    modulesNixExpr ea.evalModulesFile,
+    "--arg",
+    "pkgs",
+    toS ea.pkgsExpr
+  ]
 
 getEvalCompositionFile :: IO FilePath
 getEvalCompositionFile = getDataFileName "nix/eval-composition.nix"
 
 modeArguments :: EvaluationMode -> [[Char]]
-modeArguments ReadWrite = [ "--read-write-mode" ]
-modeArguments ReadOnly = [ "--readonly-mode" ]
+modeArguments ReadWrite = ["--read-write-mode"]
+modeArguments ReadOnly = ["--readonly-mode"]
 
 modulesNixExpr :: NonEmpty FilePath -> [Char]
 modulesNixExpr =
   NE.toList >>> fmap pathExpr >>> Data.String.unwords >>> wrapList
- where
-  pathExpr :: FilePath -> [Char]
-  pathExpr path | isAbsolute path = "(/. + \"/${" <> toNixStringLiteral path <> "}\")"
-                | otherwise       = "(./. + \"/${" <> toNixStringLiteral path <> "}\")"
+  where
+    pathExpr :: FilePath -> [Char]
+    pathExpr path
+      | isAbsolute path = "(/. + \"/${" <> toNixStringLiteral path <> "}\")"
+      | otherwise = "(./. + \"/${" <> toNixStringLiteral path <> "}\")"
 
-  isAbsolute ('/' : _) = True
-  isAbsolute _         = False
+    isAbsolute ('/' : _) = True
+    isAbsolute _ = False
 
-  wrapList s = "[ " <> s <> " ]"
+    wrapList s = "[ " <> s <> " ]"
 
 toNixStringLiteral :: [Char] -> [Char]
 toNixStringLiteral = show -- FIXME: custom escaping including '$'

--- a/src/haskell/lib/Arion/Services.hs
+++ b/src/haskell/lib/Arion/Services.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 module Arion.Services
   ( getDefaultExec

--- a/src/haskell/lib/Arion/Services.hs
+++ b/src/haskell/lib/Arion/Services.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE CPP #-}
-module Arion.Services
-  ( getDefaultExec
-  ) where
 
-import Prelude()
-import Protolude hiding (to)
+module Arion.Services
+  ( getDefaultExec,
+  )
+where
 
 import qualified Data.Aeson as Aeson
+import Protolude hiding (to)
+import Prelude ()
 #if MIN_VERSION_lens_aeson(1,2,0)
 import qualified Data.Aeson.Key as AK
 #endif
-import           Arion.Aeson (decodeFile)
-
+import Arion.Aeson (decodeFile)
 import Control.Lens
 import Data.Aeson.Lens
 
@@ -28,7 +28,6 @@ mkKey = identity
 -- | Subject to change
 getDefaultExec :: FilePath -> Text -> IO [Text]
 getDefaultExec fp service = do
-
   v <- decodeFile fp
 
   pure ((v :: Aeson.Value) ^.. key "x-arion" . key "serviceInfo" . key (mkKey service) . key "defaultExec" . _Array . traverse . _String)

--- a/src/haskell/test/Arion/NixSpec.hs
+++ b/src/haskell/test/Arion/NixSpec.hs
@@ -15,13 +15,13 @@ spec :: Spec
 spec = describe "evaluateComposition" $ do
   it "matches an example" $ do
     x <- Arion.Nix.evaluateComposition EvaluationArgs
-      { evalUid      = 123
-      , evalModules  = NEL.fromList
+      { posixUID      = 123
+      , evalModulesFile  = NEL.fromList
                          ["src/haskell/testdata/Arion/NixSpec/arion-compose.nix"]
-      , evalPkgs     = "import <nixpkgs> { system = \"x86_64-linux\"; }"
-      , evalWorkDir  = Nothing
-      , evalMode     = ReadOnly
-      , evalUserArgs = ["--show-trace"]
+      , pkgsExpr     = "import <nixpkgs> { system = \"x86_64-linux\"; }"
+      , workDir  = Nothing
+      , mode     = ReadOnly
+      , extraNixArgs = ["--show-trace"]
       }
     let actual = pretty x
     expected <- T.readFile "src/haskell/testdata/Arion/NixSpec/arion-compose.json"
@@ -29,13 +29,13 @@ spec = describe "evaluateComposition" $ do
 
   it "matches an build.context example" $ do
     x <- Arion.Nix.evaluateComposition EvaluationArgs
-      { evalUid      = 1234
-      , evalModules  = NEL.fromList
+      { posixUID      = 1234
+      , evalModulesFile  = NEL.fromList
                          ["src/haskell/testdata/Arion/NixSpec/arion-context-compose.nix"]
-      , evalPkgs     = "import <nixpkgs> { system = \"x86_64-linux\"; }"
-      , evalWorkDir  = Nothing
-      , evalMode     = ReadOnly
-      , evalUserArgs = ["--show-trace"]
+      , pkgsExpr     = "import <nixpkgs> { system = \"x86_64-linux\"; }"
+      , workDir  = Nothing
+      , mode     = ReadOnly
+      , extraNixArgs = ["--show-trace"]
       }
     let actual = pretty x
     expected <- T.readFile "src/haskell/testdata/Arion/NixSpec/arion-context-compose.json"

--- a/src/haskell/test/Arion/NixSpec.hs
+++ b/src/haskell/test/Arion/NixSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Arion.NixSpec
   ( spec
   )

--- a/src/haskell/test/Spec.hs
+++ b/src/haskell/test/Spec.hs
@@ -1,12 +1,11 @@
 module Spec
-  ( spec
+  ( spec,
   )
 where
 
-import           Test.Hspec
 import qualified Arion.NixSpec
+import Test.Hspec
 
 spec :: Spec
 spec = do
   describe "Arion.Nix" Arion.NixSpec.spec
-

--- a/src/haskell/test/TestMain.hs
+++ b/src/haskell/test/TestMain.hs
@@ -1,10 +1,11 @@
 module Main where
 
-import           Prelude()
-import           Protolude
-import           Test.Hspec.Runner
+import Protolude
 import qualified Spec
+import Test.Hspec.Runner
+import Prelude ()
 
 main :: IO ()
 main = hspecWith config Spec.spec
-  where config = defaultConfig { configColorMode = ColorAlways }
+  where
+    config = defaultConfig {configColorMode = ColorAlways}


### PR DESCRIPTION
- Reduce public flake inputs (that are copied to your lock files)
- Renames and syntax changes without behavioral change
- Format the CLI code