### PR TITLE
Update default network

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -73,7 +73,7 @@ Add this module to your NixOS configuration:
   virtualisation.docker.enable = false;
   virtualisation.podman.enable = true;
   virtualisation.podman.dockerSocket.enable = true;
-  virtualisation.podman.defaultNetwork.dnsname.enable = true;
+  virtualisation.podman.defaultNetwork.settings.dns_enabled = true;
 
   # Use your username instead of `myuser`
   users.extraUsers.myuser.extraGroups = ["podman"];


### PR DESCRIPTION
Remove option 'virtualisation.podman.defaultNetwork.dnsname.enable' to new 'virtualisation.podman.defaultNetwork.settings.dns_enabled'